### PR TITLE
Made github url and pathPrefix configurable to support GitHub enterprise

### DIFF
--- a/index.js
+++ b/index.js
@@ -32,8 +32,8 @@ if (settings.gitlab.projectID === null) {
     // optional
     //debug: true,
     protocol: "https",
-    host: "api.github.com",
-    pathPrefix: "",
+    host: settings.github.url,
+    pathPrefix: settings.github.pathPrefix,
     timeout: 5000,
     headers: {
       "user-agent": "node-gitlab-2-github" // GitHub is happy with a unique user agent

--- a/sample_settings.json
+++ b/sample_settings.json
@@ -5,6 +5,8 @@
     "projectID": null
   },
   "github": {
+    "url": "api.github.com",
+    "pathPrefix": "",
     "username": "{{username}}",
     "password": "{{password}}",
     "repo": "{{repo}}"


### PR DESCRIPTION
Hi @spruce,

I made github url and pathPrefix configurable to support GitHub enterprise - works great for me!

Thanks for merging.

Andres