### PR TITLE
Support for username mapping

### DIFF
--- a/sample_settings.json
+++ b/sample_settings.json
@@ -10,5 +10,9 @@
     "username": "{{username}}",
     "password": "{{password}}",
     "repo": "{{repo}}"
+  },
+  "usermap": {
+    "username.gitlab.1": "username.github.1",
+    "username.gitlab.2": "username.github.2",
   }
 }


### PR DESCRIPTION
Hi @spruce,

I added support for username mapping:
- Allow to define username mapping in settings
- Assign issues to github username
- Replace mentions (@username) with guthub username
- Add line at the beginning of issues and comments indicating
  author and timestamp because this gets lost during the migration

Thanks for merging.

Andres