### PR TITLE
Label issues with attachments, skip 'Added label' issue comments, support for cross-reference issue mapping

### DIFF
--- a/sample_settings.json
+++ b/sample_settings.json
@@ -13,6 +13,10 @@
   },
   "usermap": {
     "username.gitlab.1": "username.github.1",
-    "username.gitlab.2": "username.github.2",
+    "username.gitlab.2": "username.github.2"
+  },
+  "projectmap": {
+    "gitlabgroup/projectname.1": "GitHubOrg/projectname.1",
+    "gitlabgroup/projectname.2": "GitHubOrg/projectname.2"
   }
 }


### PR DESCRIPTION
Hi @spruce,

I added a number of things, I hops it's not too much

- Refactored regular expression which is used to replace usernames and cross-project issue references to be created exactly once
- Label issues which have an attachment with a label 'hasAttachment' for manual migration
- Skipping 'Added label' issue comments
- Support for cross-reference issue mapping (similar to username mapping) for cases where a project is moved or renamed during migration
- Formatting dates in the migration comment line to e.g. "Apr 12, 2016, 10:30"

Thanks for merging.

Andres