### PR TITLE
update to latest github bindings

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,4 +65,11 @@ Because Github has a limit of 5000 Api requests per hour one has to watch out th
 
 So the rule of thumb should be that one can import a repo with ~ 2500 issues without a problem.
 
+## Bugs
 
+the milestone refs and issue refs do not seem to be rewritten properly at the
+moment. specifically, milestones show up like `%4` in comments
+and issue refs like `#42` do not remap to the `#42` from gitlab under the new
+issue number in github. @ references are remapped properly (yay). If this is a
+deal breaker, a large amount of the code to do this has been written it just
+appears to no longer work in current form :(

--- a/index.js
+++ b/index.js
@@ -54,11 +54,12 @@ if (settings.gitlab.projectID === null) {
     // required
     version: "3.0.0",
     // optional
-    //debug: true,
+    debug: false,
     protocol: "https",
     host: settings.github.url,
     pathPrefix: settings.github.pathPrefix,
     timeout: 5000,
+    followRedirects: true,
     headers: {
       "user-agent": "node-gitlab-2-github" // GitHub is happy with a unique user agent
     }
@@ -204,7 +205,7 @@ function createAllIssuesAndComments(milestoneData, callback) {
 }
 
 function getAllGHMilestones(callback) {
-  github.issues.getAllMilestones({
+  github.issues.getMilestones({
     user: settings.github.owner,
     repo: settings.github.repo
   }, function(err, milestoneDataOpen) {
@@ -214,7 +215,7 @@ function getAllGHMilestones(callback) {
         console.log('FAIL!');
         process.exit(1);
       }
-    github.issues.getAllMilestones({
+    github.issues.getMilestones({
       user: settings.github.owner,
       repo: settings.github.repo,
       state: 'closed'
@@ -248,7 +249,7 @@ function getAllGHIssues(callback) {
   async.whilst(function() {
     return hasNext(lastItem)
   }, function(cb) {
-    github.issues.repoIssues({
+    github.issues.getForRepo({
       user: settings.github.owner,
       repo: settings.github.repo,
       state: 'all',

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "homepage": "https://github.com/piceaTech/node-gitlab-2-github#readme",
   "dependencies": {
     "async": "^1.4.0",
-    "github": "^0.2.4",
+    "github": "^3.0.0",
     "gitlab": "^1.4.0"
   }
 }


### PR DESCRIPTION
the previous version of the github bindings did not play nicely when using a
proxy (I can illustrate details if desired). the newer version of the bindings
seems to work, with some tweaks to the function names in the bindings.

thanks so much, this lib was super useful!

fwiw, the milestone refs and issue refs do not seem to be rewritten properly,
I am not sure if this could somehow be related to updating these bindings (it
seems not, but idk). specifically, milestones show up like `%4` in comments
and issue refs like `#42` do not remap to the `#42` from gitlab under the new
issue number in github. @ references are remapped properly (yay). I'm sorry
that I did not take the time to fix these, but highlighting for future users
who may be interested in doing so!