### PR TITLE
Migrate merge requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,12 +25,20 @@ git push --no-verify --mirror git@github.com:username/repo.git
 # Set push URL to the mirror location
 git remote set-url --push origin git@github.com:username/repo.git
 
+# Get all branches from GitLab
+git branch -r | grep -v '\->' | while read remote; do git branch --track "${remote#origin/}" "$remote"; done
+git fetch --all
+git pull --all
+
+# Push all branches to GitHub -- required for Merge Request migration
+git push --no-verify --all
+
 # To periodically update the repo on GitHub with what you have in GitLab
 git fetch -p origin
 git push --no-verify --mirror
 ```
 
-After doing this, the autolinking of issues/commits will work. See **Usage** for next steps.
+After doing this, the autolinking of issues, commits, and branches will work. See **Usage** for next steps.
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -25,14 +25,6 @@ git push --no-verify --mirror git@github.com:username/repo.git
 # Set push URL to the mirror location
 git remote set-url --push origin git@github.com:username/repo.git
 
-# Get all branches from GitLab
-git branch -r | grep -v '\->' | while read remote; do git branch --track "${remote#origin/}" "$remote"; done
-git fetch --all
-git pull --all
-
-# Push all branches to GitHub -- required for Merge Request migration
-git push --no-verify --all
-
 # To periodically update the repo on GitHub with what you have in GitLab
 git fetch -p origin
 git push --no-verify --mirror
@@ -94,7 +86,7 @@ As default it is set to false. Doesn't fire the requests to github api and only 
   
 #### mergeRequests
 
-Object consisting of `logfile` and `log`. Whether to log the merge requests existing in the gitlab repo. Currently there is no code transferring them so they only get logged out.
+Object consisting of `logfile` and `log`. If `log` is set to true, then the merge requests are logged in the specified file and not migrated. Conversely, if `log` is set to false, then the merge requests are migrated to GitHub and not logged. If the source or target branches linked to the merge request have been deleted, the merge request cannot be migrated to a pull request; instead, an issue with a custom "gitlab merge request" tag is created with the full comment history of the merge request.
 
 ### usermap
 

--- a/index.js
+++ b/index.js
@@ -123,6 +123,12 @@ async function migrate() {
 
 /**
  * Transfer any merge requests that exist in GitLab that do not exist in GitHub
+ * TODO - Update all text references to use the new issue numbers;
+ *        GitHub treats pull requests as issues, therefore their numbers are changed
+ * @param owner the owner of the GitHub repository
+ * @param repo the name of the GitHub repository
+ * @param projectId the Id of the GitLab repository that is being transferred
+ * @returns {Promise<void>}
  */
 async function transferMergeRequests(owner, repo, projectId) {
   inform("Transferring Merge Requests");

--- a/index.js
+++ b/index.js
@@ -747,14 +747,10 @@ async function updatePullRequestData(ghPullRequest, pullRequest, milestones) {
  */
 async function updatePullRequestState(ghPullRequest, pullRequest) {
 
-  if (pullRequest.state == 'merged' && !settings.debug) {
+  if (pullRequest.state == 'merged' && ghPullRequest.state != 'closed' && !settings.debug) {
 
-    return github.pulls.merge( {
-      commit_title: "",
-      commit_message: "",
-      sha: "",
-      merge_method: ""
-    });
+    // Merging the pull request adds new commits to the tree; to avoid that, just close the merge requests
+    pullRequest.state = 'closed';
   }
 
   // Default state is open so we don't have to update if the request is closed

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,9 +10,9 @@
       "integrity": "sha512-KPkoTvKwCTetu/UqonLs1pfwFO5HAqTv/Ksp9y4NAg//ZgUCpvJsT4Hrst85uEzJvkB8+LxKyR4Bfv2X8O4cmQ==",
       "requires": {
         "deepmerge": "3.0.0",
-        "is-plain-object": "2.0.4",
-        "universal-user-agent": "2.0.2",
-        "url-template": "2.0.8"
+        "is-plain-object": "^2.0.4",
+        "universal-user-agent": "^2.0.1",
+        "url-template": "^2.0.8"
       }
     },
     "@octokit/request": {
@@ -20,10 +20,10 @@
       "resolved": "https://registry.npmjs.org/@octokit/request/-/request-2.2.0.tgz",
       "integrity": "sha512-4P9EbwKZ4xfyupVMb3KVuHmM+aO2fye3nufjGKz/qDssvdJj9Rlx44O0FdFvUp4kIzToy3AHLTOulEIDAL+dpg==",
       "requires": {
-        "@octokit/endpoint": "3.1.1",
-        "is-plain-object": "2.0.4",
-        "node-fetch": "2.3.0",
-        "universal-user-agent": "2.0.2"
+        "@octokit/endpoint": "^3.0.0",
+        "is-plain-object": "^2.0.4",
+        "node-fetch": "^2.3.0",
+        "universal-user-agent": "^2.0.1"
       }
     },
     "@octokit/rest": {
@@ -32,15 +32,15 @@
       "integrity": "sha512-/D1XokSycOE+prxxI2r9cxssiLMqcr+BsEUjdruC67puEEjNJjJoRIkuA1b20jOkX5Ue3Rz99Mu9rTnNmjetUA==",
       "requires": {
         "@octokit/request": "2.2.0",
-        "before-after-hook": "1.2.0",
-        "btoa-lite": "1.0.0",
-        "lodash.get": "4.4.2",
-        "lodash.pick": "4.4.0",
-        "lodash.set": "4.3.2",
-        "lodash.uniq": "4.5.0",
-        "octokit-pagination-methods": "1.1.0",
-        "universal-user-agent": "2.0.2",
-        "url-template": "2.0.8"
+        "before-after-hook": "^1.2.0",
+        "btoa-lite": "^1.0.0",
+        "lodash.get": "^4.4.2",
+        "lodash.pick": "^4.4.0",
+        "lodash.set": "^4.3.2",
+        "lodash.uniq": "^4.5.0",
+        "octokit-pagination-methods": "^1.1.0",
+        "universal-user-agent": "^2.0.0",
+        "url-template": "^2.0.8"
       }
     },
     "asn1": {
@@ -74,7 +74,7 @@
       "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
       "optional": true,
       "requires": {
-        "tweetnacl": "0.14.5"
+        "tweetnacl": "^0.14.3"
       }
     },
     "before-after-hook": {
@@ -102,7 +102,7 @@
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.6.tgz",
       "integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
       "requires": {
-        "delayed-stream": "1.0.0"
+        "delayed-stream": "~1.0.0"
       }
     },
     "core-util-is": {
@@ -115,11 +115,11 @@
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
       "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
       "requires": {
-        "nice-try": "1.0.4",
-        "path-key": "2.0.1",
-        "semver": "5.5.0",
-        "shebang-command": "1.2.0",
-        "which": "1.3.1"
+        "nice-try": "^1.0.4",
+        "path-key": "^2.0.1",
+        "semver": "^5.5.0",
+        "shebang-command": "^1.2.0",
+        "which": "^1.2.9"
       }
     },
     "dashdash": {
@@ -127,7 +127,7 @@
       "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
       "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
       "requires": {
-        "assert-plus": "1.0.0"
+        "assert-plus": "^1.0.0"
       }
     },
     "deepmerge": {
@@ -151,7 +151,7 @@
       "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
       "optional": true,
       "requires": {
-        "jsbn": "0.1.1"
+        "jsbn": "~0.1.0"
       }
     },
     "execa": {
@@ -159,13 +159,13 @@
       "resolved": "https://registry.npmjs.org/execa/-/execa-0.10.0.tgz",
       "integrity": "sha512-7XOMnz8Ynx1gGo/3hyV9loYNPWM94jG3+3T3Y8tsfSstFmETmENCMU/A/zj8Lyaj1lkgEepKepvd6240tBRvlw==",
       "requires": {
-        "cross-spawn": "6.0.5",
-        "get-stream": "3.0.0",
-        "is-stream": "1.1.0",
-        "npm-run-path": "2.0.2",
-        "p-finally": "1.0.0",
-        "signal-exit": "3.0.2",
-        "strip-eof": "1.0.0"
+        "cross-spawn": "^6.0.0",
+        "get-stream": "^3.0.0",
+        "is-stream": "^1.1.0",
+        "npm-run-path": "^2.0.0",
+        "p-finally": "^1.0.0",
+        "signal-exit": "^3.0.0",
+        "strip-eof": "^1.0.0"
       }
     },
     "extsprintf": {
@@ -183,7 +183,7 @@
       "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.3.tgz",
       "integrity": "sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==",
       "requires": {
-        "is-callable": "1.1.4"
+        "is-callable": "^1.1.3"
       }
     },
     "forever-agent": {
@@ -196,9 +196,9 @@
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.2.tgz",
       "integrity": "sha1-SXBJi+YEwgwAXU9cI67NIda0kJk=",
       "requires": {
-        "asynckit": "0.4.0",
+        "asynckit": "^0.4.0",
         "combined-stream": "1.0.6",
-        "mime-types": "2.1.18"
+        "mime-types": "^2.1.12"
       }
     },
     "get-stream": {
@@ -211,7 +211,7 @@
       "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
       "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
       "requires": {
-        "assert-plus": "1.0.0"
+        "assert-plus": "^1.0.0"
       }
     },
     "gitlab": {
@@ -219,14 +219,14 @@
       "resolved": "https://registry.npmjs.org/gitlab/-/gitlab-4.2.7.tgz",
       "integrity": "sha512-CzSWEbyIEQrIEcxVl/IWh5yB11kk63LMI042BF0HYASNMSiUBZtHISqIPhk6toFlCgeMMn80KOeI3I/juKezow==",
       "requires": {
-        "humps": "2.0.1",
-        "parse-link-header": "1.0.1",
-        "qs": "6.5.2",
-        "request": "2.88.0",
-        "request-promise": "4.2.2",
-        "request-promise-core": "1.1.1",
-        "url-join": "4.0.0",
-        "xhr": "2.5.0"
+        "humps": "^2.0.1",
+        "parse-link-header": "^1.0.1",
+        "qs": "^6.5.2",
+        "request": "^2.88.0",
+        "request-promise": "^4.2.2",
+        "request-promise-core": "^1.1.1",
+        "url-join": "^4.0.0",
+        "xhr": "^2.5.0"
       }
     },
     "global": {
@@ -234,8 +234,8 @@
       "resolved": "https://registry.npmjs.org/global/-/global-4.3.2.tgz",
       "integrity": "sha1-52mJJopsdMOJCLEwWxD8DjlOnQ8=",
       "requires": {
-        "min-document": "2.19.0",
-        "process": "0.5.2"
+        "min-document": "^2.19.0",
+        "process": "~0.5.1"
       }
     },
     "har-schema": {
@@ -248,9 +248,9 @@
       "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
       "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
       "requires": {
-        "assert-plus": "1.0.0",
-        "jsprim": "1.4.1",
-        "sshpk": "1.14.1"
+        "assert-plus": "^1.0.0",
+        "jsprim": "^1.2.2",
+        "sshpk": "^1.7.0"
       }
     },
     "humps": {
@@ -273,7 +273,7 @@
       "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
       "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
       "requires": {
-        "isobject": "3.0.1"
+        "isobject": "^3.0.1"
       }
     },
     "is-stream": {
@@ -368,7 +368,7 @@
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.18.tgz",
       "integrity": "sha512-lc/aahn+t4/SWV/qcmumYjymLsWfN3ELhpmVuUFjgsORruuZPVSwAQryq+HHGvO/SI2KVX26bx+En+zhM8g8hQ==",
       "requires": {
-        "mime-db": "1.33.0"
+        "mime-db": "~1.33.0"
       }
     },
     "min-document": {
@@ -376,7 +376,7 @@
       "resolved": "https://registry.npmjs.org/min-document/-/min-document-2.19.0.tgz",
       "integrity": "sha1-e9KC4/WELtKVu3SM3Z8f+iyCRoU=",
       "requires": {
-        "dom-walk": "0.1.1"
+        "dom-walk": "^0.1.0"
       }
     },
     "nice-try": {
@@ -394,7 +394,7 @@
       "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
       "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
       "requires": {
-        "path-key": "2.0.1"
+        "path-key": "^2.0.0"
       }
     },
     "octokit-pagination-methods": {
@@ -407,8 +407,8 @@
       "resolved": "https://registry.npmjs.org/os-name/-/os-name-3.0.0.tgz",
       "integrity": "sha512-7c74tib2FsdFbQ3W+qj8Tyd1R3Z6tuVRNNxXjJcZ4NgjIEQU9N/prVMqcW29XZPXGACqaXN3jq58/6hoaoXH6g==",
       "requires": {
-        "macos-release": "2.0.0",
-        "windows-release": "3.1.0"
+        "macos-release": "^2.0.0",
+        "windows-release": "^3.1.0"
       }
     },
     "p-finally": {
@@ -421,7 +421,7 @@
       "resolved": "https://registry.npmjs.org/parse-headers/-/parse-headers-2.0.1.tgz",
       "integrity": "sha1-aug6eqJanZtwCswoaYzR8e1+lTY=",
       "requires": {
-        "for-each": "0.3.3",
+        "for-each": "^0.3.2",
         "trim": "0.0.1"
       }
     },
@@ -430,7 +430,7 @@
       "resolved": "https://registry.npmjs.org/parse-link-header/-/parse-link-header-1.0.1.tgz",
       "integrity": "sha1-vt/g0hGK64S+deewJUGeyKYRQKc=",
       "requires": {
-        "xtend": "4.0.1"
+        "xtend": "~4.0.1"
       }
     },
     "path-key": {
@@ -468,26 +468,26 @@
       "resolved": "https://registry.npmjs.org/request/-/request-2.88.0.tgz",
       "integrity": "sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==",
       "requires": {
-        "aws-sign2": "0.7.0",
-        "aws4": "1.8.0",
-        "caseless": "0.12.0",
-        "combined-stream": "1.0.6",
-        "extend": "3.0.2",
-        "forever-agent": "0.6.1",
-        "form-data": "2.3.2",
-        "har-validator": "5.1.3",
-        "http-signature": "1.2.0",
-        "is-typedarray": "1.0.0",
-        "isstream": "0.1.2",
-        "json-stringify-safe": "5.0.1",
-        "mime-types": "2.1.21",
-        "oauth-sign": "0.9.0",
-        "performance-now": "2.1.0",
-        "qs": "6.5.2",
-        "safe-buffer": "5.1.2",
-        "tough-cookie": "2.4.3",
-        "tunnel-agent": "0.6.0",
-        "uuid": "3.3.2"
+        "aws-sign2": "~0.7.0",
+        "aws4": "^1.8.0",
+        "caseless": "~0.12.0",
+        "combined-stream": "~1.0.6",
+        "extend": "~3.0.2",
+        "forever-agent": "~0.6.1",
+        "form-data": "~2.3.2",
+        "har-validator": "~5.1.0",
+        "http-signature": "~1.2.0",
+        "is-typedarray": "~1.0.0",
+        "isstream": "~0.1.2",
+        "json-stringify-safe": "~5.0.1",
+        "mime-types": "~2.1.19",
+        "oauth-sign": "~0.9.0",
+        "performance-now": "^2.1.0",
+        "qs": "~6.5.2",
+        "safe-buffer": "^5.1.2",
+        "tough-cookie": "~2.4.3",
+        "tunnel-agent": "^0.6.0",
+        "uuid": "^3.3.2"
       },
       "dependencies": {
         "ajv": {
@@ -495,10 +495,10 @@
           "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.6.1.tgz",
           "integrity": "sha512-ZoJjft5B+EJBjUyu9C9Hc0OZyPZSSlOF+plzouTrg6UlA8f+e/n8NIgBFG/9tppJtpPWfthHakK7juJdNDODww==",
           "requires": {
-            "fast-deep-equal": "2.0.1",
-            "fast-json-stable-stringify": "2.0.0",
-            "json-schema-traverse": "0.4.1",
-            "uri-js": "4.2.2"
+            "fast-deep-equal": "^2.0.1",
+            "fast-json-stable-stringify": "^2.0.0",
+            "json-schema-traverse": "^0.4.1",
+            "uri-js": "^4.2.2"
           }
         },
         "aws4": {
@@ -521,8 +521,8 @@
           "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.3.tgz",
           "integrity": "sha512-sNvOCzEQNr/qrvJgc3UG/kD4QtlHycrzwS+6mfTrrSq97BvaYcPZZI1ZSqGSPR73Cxn4LKTD4PttRwfU7jWq5g==",
           "requires": {
-            "ajv": "6.6.1",
-            "har-schema": "2.0.0"
+            "ajv": "^6.5.5",
+            "har-schema": "^2.0.0"
           }
         },
         "json-schema-traverse": {
@@ -540,7 +540,7 @@
           "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.21.tgz",
           "integrity": "sha512-3iL6DbwpyLzjR3xHSFNFeb9Nz/M8WDkX33t1GFQnFOllWk8pOrh/LSrB5OXlnlW5P9LH73X6loW/eogc+F5lJg==",
           "requires": {
-            "mime-db": "1.37.0"
+            "mime-db": "~1.37.0"
           }
         },
         "oauth-sign": {
@@ -558,8 +558,8 @@
           "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.4.3.tgz",
           "integrity": "sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==",
           "requires": {
-            "psl": "1.1.29",
-            "punycode": "1.4.1"
+            "psl": "^1.1.24",
+            "punycode": "^1.4.1"
           }
         },
         "uuid": {
@@ -574,10 +574,10 @@
       "resolved": "https://registry.npmjs.org/request-promise/-/request-promise-4.2.2.tgz",
       "integrity": "sha1-0epG1lSm7k+O5qT+oQGMIpEZBLQ=",
       "requires": {
-        "bluebird": "3.5.3",
+        "bluebird": "^3.5.0",
         "request-promise-core": "1.1.1",
-        "stealthy-require": "1.1.1",
-        "tough-cookie": "2.5.0"
+        "stealthy-require": "^1.1.0",
+        "tough-cookie": ">=2.3.3"
       }
     },
     "request-promise-core": {
@@ -585,7 +585,7 @@
       "resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.1.tgz",
       "integrity": "sha1-Pu4AssWqgyOc+wTFcA2jb4HNCLY=",
       "requires": {
-        "lodash": "4.17.11"
+        "lodash": "^4.13.1"
       }
     },
     "safe-buffer": {
@@ -603,7 +603,7 @@
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
       "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
       "requires": {
-        "shebang-regex": "1.0.0"
+        "shebang-regex": "^1.0.0"
       }
     },
     "shebang-regex": {
@@ -621,14 +621,14 @@
       "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.14.1.tgz",
       "integrity": "sha1-Ew9Zde3a2WPx1W+SuaxsUfqfg+s=",
       "requires": {
-        "asn1": "0.2.3",
-        "assert-plus": "1.0.0",
-        "bcrypt-pbkdf": "1.0.1",
-        "dashdash": "1.14.1",
-        "ecc-jsbn": "0.1.1",
-        "getpass": "0.1.7",
-        "jsbn": "0.1.1",
-        "tweetnacl": "0.14.5"
+        "asn1": "~0.2.3",
+        "assert-plus": "^1.0.0",
+        "bcrypt-pbkdf": "^1.0.0",
+        "dashdash": "^1.12.0",
+        "ecc-jsbn": "~0.1.1",
+        "getpass": "^0.1.1",
+        "jsbn": "~0.1.0",
+        "tweetnacl": "~0.14.0"
       }
     },
     "stealthy-require": {
@@ -646,8 +646,8 @@
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
       "integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
       "requires": {
-        "psl": "1.1.29",
-        "punycode": "2.1.1"
+        "psl": "^1.1.28",
+        "punycode": "^2.1.1"
       },
       "dependencies": {
         "punycode": {
@@ -667,7 +667,7 @@
       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
       "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
       "requires": {
-        "safe-buffer": "5.1.1"
+        "safe-buffer": "^5.0.1"
       }
     },
     "tweetnacl": {
@@ -681,7 +681,7 @@
       "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-2.0.2.tgz",
       "integrity": "sha512-nOwvHWLH3dBazyuzbECPA5uVFNd7AlgviXRHgR4yf48QqitIvpdncRrxMbZNMpPPEfgz30I9ubd1XmiJiqsTrg==",
       "requires": {
-        "os-name": "3.0.0"
+        "os-name": "^3.0.0"
       }
     },
     "uri-js": {
@@ -689,7 +689,7 @@
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
       "integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
       "requires": {
-        "punycode": "2.1.1"
+        "punycode": "^2.1.0"
       },
       "dependencies": {
         "punycode": {
@@ -714,9 +714,9 @@
       "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
       "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
       "requires": {
-        "assert-plus": "1.0.0",
+        "assert-plus": "^1.0.0",
         "core-util-is": "1.0.2",
-        "extsprintf": "1.3.0"
+        "extsprintf": "^1.2.0"
       }
     },
     "which": {
@@ -724,7 +724,7 @@
       "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
       "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
       "requires": {
-        "isexe": "2.0.0"
+        "isexe": "^2.0.0"
       }
     },
     "windows-release": {
@@ -732,7 +732,7 @@
       "resolved": "https://registry.npmjs.org/windows-release/-/windows-release-3.1.0.tgz",
       "integrity": "sha512-hBb7m7acFgQPQc222uEQTmdcGLeBmQLNLFIh0rDk3CwFOBrfjefLzEfEfmpMq8Af/n/GnFf3eYf203FY1PmudA==",
       "requires": {
-        "execa": "0.10.0"
+        "execa": "^0.10.0"
       }
     },
     "xhr": {
@@ -740,10 +740,10 @@
       "resolved": "https://registry.npmjs.org/xhr/-/xhr-2.5.0.tgz",
       "integrity": "sha512-4nlO/14t3BNUZRXIXfXe+3N6w3s1KoxcJUUURctd64BLRe67E4gRwp4PjywtDY72fXpZ1y6Ch0VZQRY/gMPzzQ==",
       "requires": {
-        "global": "4.3.2",
-        "is-function": "1.0.1",
-        "parse-headers": "2.0.1",
-        "xtend": "4.0.1"
+        "global": "~4.3.0",
+        "is-function": "^1.0.1",
+        "parse-headers": "^2.0.0",
+        "xtend": "^4.0.0"
       }
     },
     "xtend": {


### PR DESCRIPTION
Ok, so I've spent some time implementing code that migrates merge requests from GitLab to GitHub. Such migrations are not always possible; for example, if a merge request on GitLab deletes the source branch after the merge is made, an identical pull request cannot be created on GitHub because the source branch no longer exists. To work around this, I create an issue with a special "gitlab merge request" label that contains the full comment history of the merge request.

Another change I made while implementing this code is to change the order that content is migrated. The order is now Milestones, Labels, Issues, and Merge Requests. This guarantees that the Issues have the same issue numbers in both platforms. GitHub pull requests are just a special type of issue, so they are assigned issue numbers that increment from the last GitLab issue number; I have not implemented code to locate "!xxx" patterns and replace the old Merge Request numbers with the new Pull Request/Issue numbers, but this could be done relatively easily.

Finally, I tweaked the sorting for Issues and Merge Requests; `master` currently sorts by the `id`, but that method is inconsistent with the GitLab issue numbers. I changed the sorting to use `iid` as this produces the expected result.