### PR TITLE
Add option to always migrate merge requests as issues.

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,11 @@ If this is set to true (default) then the migration process will automatically c
 
 It would of course be better to find the cause for migration fails, so that no replacement issues would be needed. Finding the cause together with a retry-mechanism would be optimal, and will maybe come in the future - currently the replacement-issue-mechanism helps to keep things in order.
 
+#### useIssuesForAllMergeRequests
+
+If this is set to true (default is false) then all merge requests will be migrated as GitHub issues (rather than pull requests). This can be
+used to sidestep the problem where pull requests are rejected by GitHub if the feature branch no longer exists or has been merged.
+
 #### skipMatchingComments
 
 This is an array (empty per default) that may contain string values. Any note/comment in any issue, that contains one or more of those string values, will be skipped (meaining not migrated). Note that this is case insensitive, therefore the string value `foo` would also lead to skipping notes containing a (sub)string `FOO`.

--- a/sample_settings.ts
+++ b/sample_settings.ts
@@ -31,6 +31,7 @@ export default {
   debug: false,
   usePlaceholderIssuesForMissingIssues: true,
   useReplacementIssuesForCreationFails: true,
+  useIssuesForAllMergeRequests: false,
   skipMatchingComments: [],
   mergeRequests: {
     logFile: './merge-requests.json',

--- a/src/index.ts
+++ b/src/index.ts
@@ -66,7 +66,10 @@ const githubApi = new GitHubApi({
 });
 
 const gitlabHelper = new GitlabHelper(gitlabApi, settings.gitlab);
-const githubHelper = new GithubHelper(githubApi, settings.github, gitlabHelper);
+const githubHelper = new GithubHelper(githubApi,
+                                      settings.github,
+                                      gitlabHelper,
+                                      settings.useIssuesForAllMergeRequests);
 
 // If no project id is given in settings.js, just return
 // all of the projects that this user is associated with.


### PR DESCRIPTION
This is a simple way to create all the merge requests in the same place, particularly as GitHub throws
an error when pull requests have invalid branches, and this results in nothing being created.

Leave this turned off by default for consistency.