### PR TITLE
add useIssuesForAllMergeRequests to interface

### DIFF
--- a/src/settings.ts
+++ b/src/settings.ts
@@ -13,6 +13,7 @@ export default interface Settings {
   };
   usePlaceholderIssuesForMissingIssues: boolean;
   useReplacementIssuesForCreationFails: boolean;
+  useIssuesForAllMergeRequests: boolean;
   skipMatchingComments: string[];
   mergeRequests: {
     logFile: string;


### PR DESCRIPTION
Hello.

I was using this script to migrate my blog's code from GitLab to GitHub.
I found a problem with it and will fix it.

It seems that a setting for useIssuesForAllMergeRequests was added the other day, but the interface, src/settings.ts, didn't have a type definition in it, so it was causing an error at runtime.
```
TSError: ⨯ Unable to compile TypeScript:
src/index.ts:72:48 - error TS2339: Property 'useIssuesForAllMergeRequests' does not exist on type 'Settings'.

72                                       settings.useIssuesForAllMergeRequests);
```
So I've added the setting.