### PR TITLE
feat(releases): migrate releases from gitlab to github

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,12 @@ If this is set to true (default) then the migration process will transfer issues
 
 If this is set to true (default) then the migration process will transfer merge requests.
 
+#### transfer.releases
+
+If this is set to true (default) then the migration process will transfer releases.
+Note that github api for releases is limited and hence this will only transfer the title and description of the releases
+and add them to github in chronological order, but it would not preserve the original release dates, nor transfer artefacts or assets.
+
 #### debug
 
 As default it is set to false. Doesn't fire the requests to github api and only does the work on the gitlab side to test for wonky cases before using up api-calls

--- a/sample_settings.ts
+++ b/sample_settings.ts
@@ -33,6 +33,7 @@ export default {
     labels: true,
     issues: true,
     mergeRequests: true,
+    releases: true,
   },
   debug: false,
   usePlaceholderIssuesForMissingIssues: true,

--- a/src/githubHelper.ts
+++ b/src/githubHelper.ts
@@ -160,6 +160,62 @@ export default class GithubHelper {
 
   // ----------------------------------------------------------------------------
 
+  
+  /**
+   * Gets a release by tag name
+   * @param tag {string} - the tag name to search a release for
+   * @returns 
+   */
+   async getReleaseByTag(tag) {
+    try {
+      await utils.sleep(this.delayInMs);
+      // get an existing release by tag name in github
+      let result = await this.githubApi.repos.getReleaseByTag({
+        owner: this.githubOwner,
+        repo: this.githubRepo,
+        tag: tag
+      });
+
+      return result;
+    } catch (err) {
+      console.error('No existing release for this tag on github');
+      return null;
+    }
+  }
+
+  // ----------------------------------------------------------------------------
+
+  /**
+   * Creates a new release on github
+   * @param tag_name {string} - the tag name
+   * @param name {string} - title of the release
+   * @param body {string} - description for the release
+   */
+   async createRelease(
+    tag_name: string, 
+    name: string,
+    body: string) {
+    try {
+      await utils.sleep(this.delayInMs);
+      // get an array of GitHub labels for the new repo
+      let result = await this.githubApi.repos.createRelease({
+        owner: this.githubOwner,
+        repo: this.githubRepo,
+        tag_name,
+        name,
+        body,
+      });
+
+      return result;
+    } catch (err) {
+      console.error('Could not create release on github');
+      console.error(err);
+      return null;
+    }
+  }
+
+  // ----------------------------------------------------------------------------
+
   /**
    * Get a list of all the current GitHub pull requests.
    * This uses a while loop to make sure that each page of issues is received.

--- a/src/index.ts
+++ b/src/index.ts
@@ -156,8 +156,6 @@ async function migrate() {
         await transferMergeRequests();
       }
     }
-
-
   } catch (err) {
     console.error('Error during transfer:');
     console.error(err);
@@ -484,8 +482,8 @@ async function transferMergeRequests() {
 
   // if a GitLab release does not exist in GitHub repo, create it
   for (let release of releases) {
-    // Try to find a GitHub pull request that already exists for this GitLab
-    // merge request
+    // Try to find an existing github release that already exists for this GitLab
+    // release
     let githubRelease = await githubHelper.getReleaseByTag(release.tag_name);
     
     if (!githubRelease) {
@@ -503,12 +501,10 @@ async function transferMergeRequests() {
         console.error(err);
       }
     } else {
-      if (githubRelease) {
         console.log(
           'Gitlab release already exists (as github release): ' +
           githubRelease.data.name + ' - ' + githubRelease.data.tag_name
         );
-      }
     }
   }
 }

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -16,6 +16,7 @@ export default interface Settings {
     labels: boolean;
     issues: boolean;
     mergeRequests: boolean;
+    releases: boolean;
   };
   usePlaceholderIssuesForMissingIssues: boolean;
   useReplacementIssuesForCreationFails: boolean;


### PR DESCRIPTION
Added code to transfer releases from gitlab to github with limited functionality (due to github api limitations).