### PR TITLE
new Settings for migration when assignee users don't exist and S3 isn't used for attachment storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,18 @@ What is the name of the new repo
 
 S3 can be used to store attachments from issues. If omitted, `has attachment` label will be added to GitHub issue.
 
+#### useS3
+
+If this is set to false then the S3 processing will occur but files will not actually be posted to the S3 bucket.
+
+#### keepLocal
+
+If this is set to true then, in addition to any S3 processing, the file will also be saved in a local `attachments` directory.
+
+#### overrideURL and overrideSuffix
+
+If defined, these variables will rewrite the attachment URL to point at a custom URL, potentially instead of S3. For example, this mechanism may allow issue attachments to be hosted in a GitHub repo or other web service.
+
 #### s3.accessKeyId and s3.secretAccessKey
 
 AWS [credentials](https://docs.aws.amazon.com/general/latest/gr/aws-sec-cred-types.html#access-keys-and-secret-access-keys) that are used to copy attachments from GitLab into the S3 bucket.
@@ -107,6 +119,10 @@ If this is set to true (default) then the migration process will transfer merge 
 #### debug
 
 As default it is set to false. Doesn't fire the requests to github api and only does the work on the gitlab side to test for wonky cases before using up api-calls
+
+#### clearIssueAssignment
+
+If this is set to true then all issues will have the assignee field cleared before creation.
 
 #### usePlaceholderIssuesForMissingIssues
 

--- a/sample_settings.ts
+++ b/sample_settings.ts
@@ -13,6 +13,12 @@ export default {
     repo: '{{repo}}',
   },
   s3: {
+    useS3: false,
+    keepLocal: true,
+    // overrideURL: 'github.example.com/org/repo/raw/master',
+    overrideURL: '{{overrideURL}}',
+    // overrideSuffix if needed
+    overrideSuffix: '{{overrideSuffix}}',
     accessKeyId: '{{accessKeyId}}',
     secretAccessKey: '{{secretAccessKey}}',
     bucket: 'my-gitlab-bucket',
@@ -35,6 +41,7 @@ export default {
     mergeRequests: true,
   },
   debug: false,
+  clearIssueAssignment: false,
   usePlaceholderIssuesForMissingIssues: true,
   useReplacementIssuesForCreationFails: true,
   useIssuesForAllMergeRequests: false,

--- a/src/githubHelper.ts
+++ b/src/githubHelper.ts
@@ -222,18 +222,22 @@ export default class GithubHelper {
     // Issue Assignee
     //
 
-    // If the GitLab issue has an assignee, make sure to carry it over -- but only
-    // if the username is a valid GitHub username.
-    if (issue.assignee) {
-      props.assignees = [];
-      if (issue.assignee.username === settings.github.username) {
-        props.assignees.push(settings.github.username);
-      } else if (
-        settings.usermap &&
-        settings.usermap[issue.assignee.username]
-      ) {
-        // get GitHub username name from settings
-        props.assignees.push(settings.usermap[issue.assignee.username]);
+    if(settings.clearIssueAssignment) {
+      // do not assign new issues
+    } else {
+      // If the GitLab issue has an assignee, make sure to carry it over -- but only
+      // if the username is a valid GitHub username.
+      if (issue.assignee) {
+        props.assignees = [];
+        if (issue.assignee.username === settings.github.username) {
+          props.assignees.push(settings.github.username);
+        } else if (
+          settings.usermap &&
+          settings.usermap[issue.assignee.username]
+        ) {
+          // get GitHub username name from settings
+          props.assignees.push(settings.usermap[issue.assignee.username]);
+        }
       }
     }
 
@@ -677,20 +681,27 @@ export default class GithubHelper {
     // Pull Request Assignee
     //
 
-    // If the GitLab merge request has an assignee, make sure to carry it over --
-    // but only if the username is a valid GitHub username
-    if (pullRequest.assignee) {
-      props.assignees = [];
-      if (pullRequest.assignee.username === settings.github.username) {
-        props.assignees.push(settings.github.username);
-      } else if (
-        settings.usermap &&
-        settings.usermap[pullRequest.assignee.username]
-      ) {
-        // Get GitHub username from settings
-        props.assignees.push(settings.usermap[pullRequest.assignee.username]);
+    if (pullRequest.assignee){
+      if(settings.clearIssueAssignment) {
+        // do not assign new issues
+        props.assignees = [];
+      } else {
+      // If the GitLab merge request has an assignee, make sure to carry it over --
+      // but only if the username is a valid GitHub username
+        props.assignees = [];
+        if (pullRequest.assignee.username === settings.github.username) {
+          props.assignees.push(settings.github.username);
+        } else if (
+          settings.usermap &&
+          settings.usermap[pullRequest.assignee.username]
+        ) {
+          // Get GitHub username from settings
+          props.assignees.push(settings.usermap[pullRequest.assignee.username]);
+        }
       }
     }
+
+
 
     //
     // Pull Request Milestone

--- a/src/gitlabHelper.ts
+++ b/src/gitlabHelper.ts
@@ -92,7 +92,7 @@ export default class GitlabHelper {
     try {
       const host = this.host.endsWith('/') ? this.host : this.host + '/';
       const attachmentUrl = host + this.projectPath + relurl;
-      const data = (await axios.get(attachmentUrl, {responseType: 'arraybuffer'})).data;
+      const data = (await axios.get(encodeURI(attachmentUrl), {responseType: 'arraybuffer'})).data;
       return Buffer.from(data, 'binary')
     } catch (err) {
       console.error(`Could not download attachment #${relurl}.`);

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -17,6 +17,7 @@ export default interface Settings {
     issues: boolean;
     mergeRequests: boolean;
   };
+  clearIssueAssignment: boolean;
   usePlaceholderIssuesForMissingIssues: boolean;
   useReplacementIssuesForCreationFails: boolean;
   useIssuesForAllMergeRequests: boolean;
@@ -45,6 +46,10 @@ export interface GitlabSettings {
 }
 
 export interface S3Settings {
+  useS3: boolean;
+  keepLocal: boolean;
+  overrideURL: string;
+  overrideSuffix: string;
   accessKeyId: string;
   secretAccessKey: string;
   bucket: string;


### PR DESCRIPTION
Created settings for clearing issue assignees, bypassing S3 bucket upload, saving issue
attachments locally, and rewriting attachment URLs in issue content. Fixed problem downloading
attachments with international characters by encoding attachment download URIs.