### PR TITLE
Transfer repository description by default

### DIFF
--- a/sample_settings.ts
+++ b/sample_settings.ts
@@ -29,6 +29,7 @@ export default {
     useLowerCaseLabels: true,
   },
   transfer: {
+    description: true,
     milestones: true,
     labels: true,
     issues: true,

--- a/src/githubHelper.ts
+++ b/src/githubHelper.ts
@@ -206,6 +206,20 @@ export default class GithubHelper {
    */
 
   /**
+   * Update the description of the repository on GitHub.
+   * Replaces newlines and tabs with spaces. No attempt is made to remove e.g. Markdown
+   * links or other special formatting.
+   */
+  async updateRepositoryDescription(description) {
+    let props : RestEndpointMethodTypes["repos"]["update"]["parameters"] = {
+      owner: this.githubOwner,
+      repo: this.githubRepo,
+      description: description.replace(/\s+/g, " ")
+    }
+    return this.githubApi.repos.update(props);
+  }
+
+  /**
    * TODO description
    */
   async createIssue(milestones, issue) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -127,6 +127,11 @@ async function migrate() {
 
     await githubHelper.registerRepoId();
 
+    // transfer GitLab description to GitHub
+    if (settings.transfer.description) {
+      await transferDescription();
+    }
+
     // transfer GitLab milestones to GitHub
     if (settings.transfer.milestones) {
       await transferMilestones();
@@ -155,6 +160,22 @@ async function migrate() {
   }
 
   console.log('\n\nTransfer complete!\n\n');
+}
+
+// ----------------------------------------------------------------------------
+
+/**
+ * Transfer the description of the repository.
+ */
+async function transferDescription() {
+  inform('Transferring Description');
+
+  // Get the description of this project
+  let project = await gitlabApi.Projects.show(
+    settings.gitlab.projectId
+  ) as any;
+
+  await githubHelper.updateRepositoryDescription(project.description);
 }
 
 // ----------------------------------------------------------------------------

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -12,6 +12,7 @@ export default interface Settings {
     useLowerCaseLabels: boolean;
   };
   transfer: {
+    description: boolean;
     milestones: boolean;
     labels: boolean;
     issues: boolean;


### PR DESCRIPTION
This patch enables copying the project description from GitLab as the repository description on GitHub. Control characters disallowed by GitHub (like newlines) are turned into whitespace. No attempt is made to translate anything else like Markdown links or other formatting.