### PR TITLE
Indicate migration status using topics

### DIFF
--- a/sample_settings.ts
+++ b/sample_settings.ts
@@ -33,6 +33,7 @@ export default {
     labels: true,
     issues: true,
     mergeRequests: true,
+    migrationTopic: false,
   },
   debug: false,
   usePlaceholderIssuesForMissingIssues: true,

--- a/src/githubHelper.ts
+++ b/src/githubHelper.ts
@@ -206,6 +206,18 @@ export default class GithubHelper {
    */
 
   /**
+   * Replace the topics of the repository on GitHub.
+   */
+  async replaceTopics(topics) {
+    let props : RestEndpointMethodTypes["repos"]["replaceAllTopics"]["parameters"] = {
+      owner: this.githubOwner,
+      repo: this.githubRepo,
+      names: topics
+    }
+    return this.githubApi.repos.replaceAllTopics(props);
+  }
+ 
+  /**
    * TODO description
    */
   async createIssue(milestones, issue) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -127,6 +127,11 @@ async function migrate() {
 
     await githubHelper.registerRepoId();
 
+    // set the gitlab-mr-migrating topic for the repository during the migration
+    if (settings.transfer.migrationTopic) {
+      await setMigratingTopic();
+    }
+
     // transfer GitLab milestones to GitHub
     if (settings.transfer.milestones) {
       await transferMilestones();
@@ -154,7 +159,32 @@ async function migrate() {
     console.error(err);
   }
 
+  // set the gitlab-mr-migrated topic for the repository when migration is done
+  if (settings.transfer.migrationTopic) {
+    await setMigratedTopic();
+  }
+
   console.log('\n\nTransfer complete!\n\n');
+}
+
+// ----------------------------------------------------------------------------
+
+/**
+ * Set the gitlab-mr-migrating topic.
+ */
+async function setMigratingTopic() {
+  inform('Setting the gitlab-mr-migrating topic during the transfer');
+  await githubHelper.replaceTopics(['gitlab-mr-migrating']);
+}
+
+// ----------------------------------------------------------------------------
+
+/**
+ * Set the gitlab-mr-migrated topic.
+ */
+async function setMigratedTopic() {
+  inform('Setting the gitlab-mr-migrated topic during the transfer');
+  await githubHelper.replaceTopics(['gitlab-mr-migrated']);
 }
 
 // ----------------------------------------------------------------------------

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -16,6 +16,7 @@ export default interface Settings {
     labels: boolean;
     issues: boolean;
     mergeRequests: boolean;
+    migrationTopic: boolean;
   };
   usePlaceholderIssuesForMissingIssues: boolean;
   useReplacementIssuesForCreationFails: boolean;


### PR DESCRIPTION
This setting enables setting a `github-mr-migrating` GitHub repository topic for the duration of the migration, and a `github-mr-migrated` topic to signal completion.

Given a lot of repositories to migrate, this provides a way to track the migration process from the GitHub UI.