### PR TITLE
Closes #114: always compute gitlab project path

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -126,6 +126,7 @@ async function migrate() {
   try {
 
     await githubHelper.registerRepoId();
+    await gitlabHelper.registerProjectPath(settings.gitlab.projectId);
 
     // transfer GitLab milestones to GitHub
     if (settings.transfer.milestones) {
@@ -249,8 +250,6 @@ async function transferLabels(attachmentLabel = true, useLowerCase = true) {
  */
 async function transferIssues() {
   inform('Transferring Issues');
-
-  await gitlabHelper. registerProjectPath(settings.gitlab.projectId);
 
   // Because each
   let milestoneData = await githubHelper.getAllGithubMilestones();


### PR DESCRIPTION
This PR only moves the computation to the beginning of the transfer, irrespective of what is transferred. Closes #114 