### PR TITLE
New feature: Option to use issue import preview API

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,10 @@ Under which organisation or user will the new project be hosted
 
 Go to [Settings / Developer settings / Personal access tokens](https://github.com/settings/tokens). Generate a new token with `repo` scope and copy that into the `settings.ts`
 
+#### github.token_owner
+
+Set to the user name of the user whose token is used (see above). This is required to determine whether the user running the migration is also the creator of comments and issues. If this is the case and `useIssueCreationAPI` is true (see below), the extra line specifying who created a comment or issue will not be added.
+
 #### github.repo
 
 What is the name of the new repo

--- a/README.md
+++ b/README.md
@@ -108,6 +108,10 @@ If this is set to true (default) then the migration process will transfer merge 
 
 As default it is set to false. Doesn't fire the requests to github api and only does the work on the gitlab side to test for wonky cases before using up api-calls
 
+#### useIssueImportAPI
+
+Set to true (default) to enable using the [GitHub preview API for importing issues](https://gist.github.com/jonmagic/5282384165e0f86ef105). This allows setting the date for issues and comments instead of inserting an additional line in the body.
+
 #### usePlaceholderIssuesForMissingIssues
 
 If this is set to true (default) then the migration process will automatically create empty dummy issues for every 'missing' GitLab issue (if you deleted an GitLab issue for example). Those issues will be closed on Github and they ensure, that the issue ids stay the same on both, GitLab and Github.

--- a/sample_settings.ts
+++ b/sample_settings.ts
@@ -35,6 +35,7 @@ export default {
     mergeRequests: true,
   },
   debug: false,
+  useIssueImportAPI: true,
   usePlaceholderIssuesForMissingIssues: true,
   useReplacementIssuesForCreationFails: true,
   useIssuesForAllMergeRequests: false,

--- a/sample_settings.ts
+++ b/sample_settings.ts
@@ -10,6 +10,7 @@ export default {
     // baseUrl: 'https://gitlab.mycompany.com:123/etc',
     owner: '{{repository owner (user or organization)}}',
     token: '{{token}}',
+    token_owner: '{{token_owner}}',
     repo: '{{repo}}',
   },
   s3: {

--- a/src/githubHelper.ts
+++ b/src/githubHelper.ts
@@ -284,7 +284,10 @@ export default class GithubHelper {
         let lower = l.toLowerCase();
         // ignore any labels that should have been removed when the issue was closed
         return lower !== 'doing' && lower !== 'to do';
-      }).map((el : string) => el.toLowerCase());
+      });
+      if (settings.conversion.useLowerCaseLabels) {
+        props.labels = props.labels.map((el : string) => el.toLowerCase());
+      }
     }
 
     //
@@ -364,7 +367,10 @@ export default class GithubHelper {
         let lower = l.toLowerCase();
         // ignore any labels that should have been removed when the issue was closed
         return lower !== 'doing' && lower !== 'to do';
-      }).map((el : string) => el.toLowerCase());
+      });
+      if (settings.conversion.useLowerCaseLabels) {
+        props.labels = props.labels.map((el : string) => el.toLowerCase());
+      }
     }
 
     //
@@ -376,7 +382,7 @@ export default class GithubHelper {
     if (props.body && props.body.indexOf('/uploads/') > -1 && !settings.s3) {
       props.labels.push('has attachment');
     }
-    
+
     // Is this OK? It will just return the argument
     if (settings.debug) return Promise.resolve({ data: issue });
 
@@ -466,6 +472,8 @@ export default class GithubHelper {
     if (result.data.status === "failed") {
       console.log("\tFAILED: ");
       console.log(result);
+      console.log("\tERRORS:")
+      console.log(result.data.errors);
       return null;
     }
 

--- a/src/githubHelper.ts
+++ b/src/githubHelper.ts
@@ -375,8 +375,8 @@ export default class GithubHelper {
     if (props.body && props.body.indexOf('/uploads/') > -1 && !settings.s3) {
       props.labels.push('has attachment');
     }
-    await utils.sleep(this.delayInMs);
-
+    
+    // Is this OK? It will just return the argument
     if (settings.debug) return Promise.resolve({ data: issue });
 
 

--- a/src/githubHelper.ts
+++ b/src/githubHelper.ts
@@ -1097,7 +1097,7 @@ export default class GithubHelper {
       return str;
     }
 
-    const dateformatOptions = {
+    const dateformatOptions : Intl.DateTimeFormatOptions = {
       month: 'short',
       day: 'numeric',
       year: 'numeric',

--- a/src/githubHelper.ts
+++ b/src/githubHelper.ts
@@ -279,7 +279,7 @@ export default class GithubHelper {
         let lower = l.toLowerCase();
         // ignore any labels that should have been removed when the issue was closed
         return lower !== 'doing' && lower !== 'to do';
-      });
+      }).map((el : string) => el.toLowerCase());
     }
 
     //

--- a/src/githubHelper.ts
+++ b/src/githubHelper.ts
@@ -220,6 +220,11 @@ export default class GithubHelper {
    ******************************** POST METHODS ********************************
    ******************************************************************************
    */
+   userIsCreator(author) {
+    return author && 
+      ((settings.usermap && settings.usermap[author.username] === settings.github.token_owner) ||
+       (author.username === settings.github.token_owner));
+  }
 
   /**
    * TODO description
@@ -308,14 +313,10 @@ export default class GithubHelper {
    */
   async importIssueAndComments(milestones, issue) {
 
-    let userIsCreator = issue.author && 
-      ((settings.usermap && settings.usermap[issue.author.username] === settings.github.token_owner) ||
-       (issue.author.username === settings.github.token_owner));
-
     let props : IssueImport = {
       title: issue.title.trim(),
       body: await this.convertIssuesAndComments(
-        issue.description, issue, !userIsCreator || !issue.description),
+        issue.description, issue, !this.userIsCreator(issue.author) || !issue.description),
       created_at: issue.created_at,
       updated_at: issue.updated_at,
       closed: issue.state === 'closed'
@@ -786,10 +787,7 @@ export default class GithubHelper {
 
     // Failing all else, create an issue with a descriptive title
 
-    let userIsCreator = pullRequest.author && 
-      ((settings.usermap && settings.usermap[pullRequest.author.username] === settings.github.token_owner) ||
-       (pullRequest.author.username === settings.github.token_owner));
-
+    
     let mergeStr =
       '_Merges ' +
       pullRequest.source_branch +
@@ -799,7 +797,7 @@ export default class GithubHelper {
     let bodyConverted = await this.convertIssuesAndComments(
       mergeStr + pullRequest.description,
       pullRequest,
-      !userIsCreator || !settings.useIssueImportAPI
+      !this.userIsCreator(pullRequest.author) || !settings.useIssueImportAPI
     );
 
     if (settings.useIssueImportAPI) {          

--- a/src/gitlabHelper.ts
+++ b/src/gitlabHelper.ts
@@ -14,6 +14,7 @@ export default class GitlabHelper {
 
   host: string;
   projectPath?: string;
+  allBranches: any;
 
   constructor(
     gitlabApi: InstanceType<typeof Gitlab>,
@@ -24,6 +25,7 @@ export default class GitlabHelper {
     this.gitlabToken = gitlabSettings.token;
     this.gitlabProjectId = gitlabSettings.projectId;
     this.host = gitlabSettings.url ? gitlabSettings.url : 'http://gitlab.com';
+    this.allBranches = null;
   }
 
   /**
@@ -104,7 +106,10 @@ export default class GitlabHelper {
    * Gets all branches.
    */
   async getAllBranches() {
-    return (await this.gitlabApi.Branches.all(this.gitlabProjectId)) as any[];
+    if (!this.allBranches){
+      this.allBranches = await this.gitlabApi.Branches.all(this.gitlabProjectId);
+    }
+    return this.allBranches as any[];
   }
 
   /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -53,6 +53,7 @@ const gitlabApi = new Gitlab({
 
 // Create a GitHub API object
 const githubApi = new GitHubApi({
+  previews: settings.useIssueImportAPI ? ["golden-comet"] : [],
   debug: false,
   baseUrl: settings.github.baseUrl
     ? settings.github.baseUrl

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -34,6 +34,7 @@ export interface GithubSettings {
   baseUrl?: string;
   owner: string;
   token: string;
+  token_owner: string;
   repo: string;
   timeout?: number;
   username?: string; // when is this set???

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -17,6 +17,7 @@ export default interface Settings {
     issues: boolean;
     mergeRequests: boolean;
   };
+  useIssueImportAPI: boolean;
   usePlaceholderIssuesForMissingIssues: boolean;
   useReplacementIssuesForCreationFails: boolean;
   useIssuesForAllMergeRequests: boolean;


### PR DESCRIPTION
This PR:
* adds an option to use the preview API for issue imports. This enables setting the creation and modification date of issues and comments.
* documents it
* adds `settings.github.token_owner`. Required to check ownership of comments against the user creating the new content on GH.

Additionally, it:

* caches a call to getAllBranches()
* Fixes a typing problem in https://github.com/piceaTech/node-gitlab-2-github/blob/7572017dfbcb0a7a2a8917ab6cb99ebe2c173877/src/githubHelper.ts#L858
* Fixes a problem whereby labels are not converted to lowercase before using them in `createIssue()`: https://github.com/piceaTech/node-gitlab-2-github/blob/7572017dfbcb0a7a2a8917ab6cb99ebe2c173877/src/githubHelper.ts#L258