### PR TITLE
Fixes for S3 attachments

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,10 @@ Go to [Settings / Access Tokens](https://gitlab.com/profile/personal_access_toke
 
 Leave it null for the first run of the script. Then the script will show you which projects there are. Can be either string or number.
 
+#### gitlab.sessionCookie
+
+GitLab's API [does not allow downloading of attachments](https://gitlab.com/gitlab-org/gitlab/-/issues/24155) and only images can be downloaded using HTTP. To work around this limitation and enable binary attachments to be migrated one can use the session cookie set in the browser after logging in to the gitlab instance. The cookie is named `_gitlab_session`.
+
 ### github
 
 #### github.baseUrl

--- a/sample_settings.ts
+++ b/sample_settings.ts
@@ -5,6 +5,7 @@ export default {
     // url: 'https://gitlab.mycompany.com',
     token: '{{gitlab private token}}',
     projectId: null,
+    sessionCookie: null,
   },
   github: {
     // baseUrl: 'https://gitlab.mycompany.com:123/etc',

--- a/src/githubHelper.ts
+++ b/src/githubHelper.ts
@@ -825,9 +825,7 @@ export default class GithubHelper {
         }
       );
 
-      if (settings.s3) {
-        strWithMigLine = await utils.migrateAttachments(strWithMigLine, this.repoId, settings.s3, this.gitlabHelper);
-      }
+      strWithMigLine = await utils.migrateAttachments(strWithMigLine, this.repoId, settings.s3, this.gitlabHelper);
 
       return strWithMigLine;
     }

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -42,6 +42,7 @@ export interface GitlabSettings {
   url?: string;
   token: string;
   projectId: number;
+  sessionCookie: string;
 }
 
 export interface S3Settings {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -47,42 +47,53 @@ export const migrateAttachments = async (body: string, githubRepoId: number | un
   for (const match of matches) {
     const name = match[1];
     const url = match[2];
+    if (s3 && s3.bucket) {
+      const basename = path.basename(url);
+      const extension = path.extname(url);
+      const mimeType = mime.lookup(basename);
+      const attachmentBuffer = await gitlabHelper.getAttachment(url);
+      if (!attachmentBuffer) {
+        continue;
+      }
 
-    const basename = path.basename(url);
-    const extension = path.extname(url);
-    const mimeType = mime.lookup(basename);
-    const attachmentBuffer = await gitlabHelper.getAttachment(url);
+      // // Generate file name for S3 bucket from URL
+      const hash = crypto.createHash('sha256');
+      hash.update(url);
+      const newFileName = hash.digest('hex') + extension
+      const relativePath = githubRepoId ? `${githubRepoId}/${newFileName}` : newFileName;
+      // Doesn't seem like it is easy to upload an issue to github, so upload to S3
+      //https://stackoverflow.com/questions/41581151/how-to-upload-an-image-to-use-in-issue-comments-via-github-api
 
-    // Generate new random file name for S3 bucket
-    const id = crypto.randomBytes(16).toString('hex');
-    const newFileName = id + extension;
-    const relativePath = githubRepoId ? `${githubRepoId}/${newFileName}` : newFileName;
+      const s3url = `https://${s3.bucket}.s3.amazonaws.com/${relativePath}`;
 
-    // Doesn't seem like it is easy to upload an issue to github, so upload to S3
-    //https://stackoverflow.com/questions/41581151/how-to-upload-an-image-to-use-in-issue-comments-via-github-api
+      const s3bucket = new S3();
+      s3bucket.createBucket(() => {
+        const params: S3.PutObjectRequest = {
+          Key: relativePath,
+          Body: attachmentBuffer,
+          ContentType: mimeType === false ? null : mimeType,
+          Bucket: s3.bucket,
+        };
 
-    const s3url = `https://${s3.bucket}.s3.amazonaws.com/${relativePath}`;
-
-    const s3bucket = new S3();
-    s3bucket.createBucket(() => {
-      const params: S3.PutObjectRequest = {
-        Key: relativePath,
-        Body: attachmentBuffer,
-        ContentType: mimeType === false ? null : mimeType,
-        Bucket: s3.bucket,
-      };
-
-      s3bucket.upload(params, function (err, data) {
-        console.log(`\tUploaded ${basename} to ${s3url}`);
-        if (err) {
-          console.log('ERROR MSG: ', err);
-        }
+        s3bucket.upload(params, function (err, data) {
+          console.log(`\tUploading ${basename} to ${s3url}... `);
+          if (err) {
+            console.log('ERROR: ', err);
+          } else {
+            console.log(`\t... success`);
+          }
+        });
       });
-    });
-
-    // Add the new URL to the map
-    offsetToAttachment[match.index] = `![${name}](${s3url})`;
-
+    
+      // Add the new URL to the map
+      offsetToAttachment[match.index] = `![${name}](${s3url})`;
+    } else {
+      // Not using S3: default to old URL, adding absolute path
+      const host = gitlabHelper.host.endsWith('/') 
+                    ? gitlabHelper.host : gitlabHelper.host + '/';
+      const attachmentUrl = host + gitlabHelper.projectPath + url;
+      offsetToAttachment[match.index] = `![${name}](${attachmentUrl})`;
+    }
   }
 
   return body.replace(regexp, ({},{},{},offset,{}) => offsetToAttachment[offset]);

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -81,7 +81,7 @@ export const migrateAttachments = async (body: string, githubRepoId: number | un
           if (err) {
             console.log('ERROR: ', err);
           } else {
-            console.log(`\t... success`);
+            console.log(`\t...Done uploading`);
           }
         });
       });
@@ -97,5 +97,5 @@ export const migrateAttachments = async (body: string, githubRepoId: number | un
     }
   }
 
-  return body.replace(regexp, ({},{},{},offset,{}) => offsetToAttachment[offset]);
+  return body.replace(regexp, ({},{},{},{},offset,{}) => offsetToAttachment[offset]);
 };


### PR DESCRIPTION
This PR:
* Closes #107: uses a hash of the attachment's URL to avoid duplicates upon failure
* Closes #103: Doesn't fail if there was an error downloading an attachment
* Closes #106: migrates arbitrary attachment types using a browser cookie (workaround for [GitLab's missing API endpoint](https://gitlab.com/gitlab-org/gitlab/-/issues/24155))
* Uses previous attachment URL if S3 is not configured