### PR TITLE
Skip merge requests in given states

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,10 @@ used to sidestep the problem where pull requests are rejected by GitHub if the f
 
 Filters all merge requests and issues by these labels. The applicable values can be found in the Gitlab API documentation for [issues](https://docs.gitlab.com/ee/api/issues.html#list-project-issues) and [merge requests](https://docs.gitlab.com/ee/api/merge_requests.html#list-merge-requests) respectively. Default is `null` which returns all issues/merge requests.
 
+#### skipMergeRequestStates
+
+Merge requests in GitLab with any of the states listed in this array will not be transferred to GitHub (e.g. set to `['merged', 'closed']` to avoid creating issues for closed MRs whose branches have been deleted).
+
 #### skipMatchingComments
 
 This is an array (empty per default) that may contain string values. Any note/comment in any issue, that contains one or more of those string values, will be skipped (meaining not migrated). Note that this is case insensitive, therefore the string value `foo` would also lead to skipping notes containing a (sub)string `FOO`.

--- a/sample_settings.ts
+++ b/sample_settings.ts
@@ -39,6 +39,7 @@ export default {
   useReplacementIssuesForCreationFails: true,
   useIssuesForAllMergeRequests: false,
   filterByLabel: null,
+  skipMergeRequestStates: [],
   skipMatchingComments: [],
   mergeRequests: {
     logFile: './merge-requests.json',

--- a/src/index.ts
+++ b/src/index.ts
@@ -411,6 +411,10 @@ async function transferMergeRequests() {
       i => i.title.trim().includes(request.title.trim())
     );
     if (!githubRequest && !githubIssue) {
+      if (settings.skipMergeRequestStates.includes(request.state)) {
+          console.log(`Skipping MR ${request.iid} in "${request.state}" state: ${request.title}`)
+          continue;
+        }
       console.log(
         'Creating pull request: !' + request.iid + ' - ' + request.title
       );

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -21,6 +21,7 @@ export default interface Settings {
   useReplacementIssuesForCreationFails: boolean;
   useIssuesForAllMergeRequests: boolean;
   filterByLabel: string | null;
+  skipMergeRequestStates: string[];
   skipMatchingComments: string[];
   mergeRequests: {
     logFile: string;


### PR DESCRIPTION
This PR adds a new config variable `skipMergeRequestStates` which is an array of strings. Merge requests with a state listed in this array will not be migrated. Closes #105