### PR TITLE
Option to recreate GitHub repository

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -19,7 +19,8 @@
         "src/index.ts"
       ],
       "protocol": "inspector",
-      "sourceMaps": true
+      "sourceMaps": true,
+      "console": "integratedTerminal"
     }
   ]
 }

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ What is the name of the new repo
 
 #### github.recreateRepo
 
-If true (default is false), we will try to delete the destination github repository if present, and (re)create it. The github token must be granted `delete_repo` scope.
+If true (default is false), we will try to delete the destination github repository if present, and (re)create it. The github token must be granted `delete_repo` scope. The newly created repository will be made private by default.
 
 This is useful when debugging this tool or a specific migration. You will always be prompted for confirmation.
 

--- a/README.md
+++ b/README.md
@@ -84,7 +84,9 @@ What is the name of the new repo
 
 #### github.recreateRepo
 
-If true (default is false), we will try to delete the destination github repository if present, and (re)create it. This is useful when debugging this tool or a specific migration. You will always be prompted for confirmation.
+If true (default is false), we will try to delete the destination github repository if present, and (re)create it. The github token must be granted `delete_repo` scope.
+
+This is useful when debugging this tool or a specific migration. You will always be prompted for confirmation.
 
 ### s3 (optional)
 

--- a/README.md
+++ b/README.md
@@ -82,6 +82,10 @@ Set to the user name of the user whose token is used (see above). This is requir
 
 What is the name of the new repo
 
+#### github.recreateRepo
+
+If true (default is false), we will try to delete the destination github repository if present, and (re)create it. This is useful when debugging this tool or a specific migration. You will always be prompted for confirmation.
+
 ### s3 (optional)
 
 S3 can be used to store attachments from issues. If omitted, `has attachment` label will be added to GitHub issue.

--- a/package-lock.json
+++ b/package-lock.json
@@ -336,6 +336,12 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.5.tgz",
       "integrity": "sha512-LMy+vDDcQR48EZdEx5wRX1q/sEl6NdGuHXPnfeL8ixkwCOSZ2qnIyIZmcCbdX0MeRqHhAcHmX+haCbrS8Run+A=="
     },
+    "@types/readline-sync": {
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/@types/readline-sync/-/readline-sync-1.4.4.tgz",
+      "integrity": "sha512-cFjVIoiamX7U6zkO2VPvXyTxbFDdiRo902IarJuPVxBhpDnXhwSaVE86ip+SCuyWBbEioKCkT4C88RNTxBM1Dw==",
+      "dev": true
+    },
     "@types/responselike": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@types/responselike/-/responselike-1.0.0.tgz",
@@ -690,9 +696,9 @@
       "integrity": "sha1-mzERErxsYSehbgFsbF1/GeCAXFs="
     },
     "follow-redirects": {
-      "version": "1.14.6",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.6.tgz",
-      "integrity": "sha512-fhUl5EwSJbbl8AR+uYL2KQDxLkdSjZGR36xy46AO7cOMTrCMON6Sa28FmAnC2tRTDbd/Uuzz3aJBv7EBN7JH8A=="
+      "version": "1.14.7",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.7.tgz",
+      "integrity": "sha512-+hbxoLbFMbRKDwohX8GkTataGqO6Jb7jGwpAlwgy2bIz25XtRm7KEzJM76R1WiNT5SwZkX4Y75SwBolkpmE7iQ=="
     },
     "form-data": {
       "version": "4.0.0",
@@ -1248,6 +1254,11 @@
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-5.1.1.tgz",
       "integrity": "sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA=="
+    },
+    "readline-sync": {
+      "version": "1.4.10",
+      "resolved": "https://registry.npmjs.org/readline-sync/-/readline-sync-1.4.10.tgz",
+      "integrity": "sha512-gNva8/6UAe8QYepIQH/jQ2qn91Qj0B9sYjMBBs3QOB8F2CXcKgLxQaJRP76sWVRQt+QU+8fAkCbCvjjMFu7Ycw=="
     },
     "resolve-alpn": {
       "version": "1.2.1",

--- a/package.json
+++ b/package.json
@@ -33,11 +33,13 @@
     "aws-sdk": "^2.1053.0",
     "axios": "^0.24.0",
     "mime-types": "^2.1.34",
+    "readline-sync": "^1.4.10",
     "ts-node": "^10.4.0"
   },
   "devDependencies": {
     "@types/mime-types": "^2.1.1",
-    "@types/node": "^14.0.20",
+    "@types/node": "^14.18.5",
+    "@types/readline-sync": "^1.4.4",
     "husky": "^7.0.4",
     "lint-staged": "^12.1.7",
     "prettier": "^2.5.1",

--- a/sample_settings.ts
+++ b/sample_settings.ts
@@ -13,6 +13,7 @@ export default {
     token: '{{token}}',
     token_owner: '{{token_owner}}',
     repo: '{{repo}}',
+    recreateRepo: false,
   },
   s3: {
     accessKeyId: '{{accessKeyId}}',

--- a/src/githubHelper.ts
+++ b/src/githubHelper.ts
@@ -1260,4 +1260,29 @@ export class GithubHelper {
     const ref = path && line ? `${path} line ${line}` : `${head_sha}`;
     return `Commented on [${ref}](${repoLink}/compare/${base_sha}..${head_sha}${slug})\n\n`;
   }
+
+  async recreateRepo() {
+    let params = {
+      owner: this.githubOwner,
+      repo: this.githubRepo,
+    };
+
+    try {
+      process.stdout.write(`Deleting repo ${params.owner}/${params.repo}...`);
+      await this.githubApi.repos.delete(params);
+      process.stdout.write(' done.');
+    } catch (err) {
+      if (err.status == 404) process.stdout.write(' not found.');
+      else console.error(`\n\tSomething went wrong: ${err}.`);
+    }
+    try {
+      process.stdout.write(`Creating repo ${params.owner}/${params.repo}...`);
+      await this.githubApi.repos.createForAuthenticatedUser({
+        name: this.githubRepo,
+      });
+      process.stdout.write(' done.');
+    } catch (err) {
+      console.error(`\n\tSomething went wrong: ${err}.`);
+    }
+  }
 }

--- a/src/githubHelper.ts
+++ b/src/githubHelper.ts
@@ -1262,7 +1262,7 @@ export class GithubHelper {
   }
 
   /**
-   * Asks for confirmation and then maybe deletes the GH repository, then creates it again.
+   * Deletes the GH repository, then creates it again.
    */
   async recreateRepo() {
     let params = {

--- a/src/githubHelper.ts
+++ b/src/githubHelper.ts
@@ -1271,19 +1271,19 @@ export class GithubHelper {
     };
 
     try {
-      process.stdout.write(`Deleting repo ${params.owner}/${params.repo}...`);
+      console.log(`Deleting repo ${params.owner}/${params.repo}...`);
       await this.githubApi.repos.delete(params);
-      process.stdout.write(' done.');
+      console.log('\t...done.');
     } catch (err) {
-      if (err.status == 404) process.stdout.write(' not found.');
+      if (err.status == 404) console.log(' not found.');
       else console.error(`\n\tSomething went wrong: ${err}.`);
     }
     try {
-      process.stdout.write(`Creating repo ${params.owner}/${params.repo}...`);
+      console.log(`Creating repo ${params.owner}/${params.repo}...`);
       await this.githubApi.repos.createForAuthenticatedUser({
         name: this.githubRepo,
       });
-      process.stdout.write(' done.');
+      console.log('\t...done.');
     } catch (err) {
       console.error(`\n\tSomething went wrong: ${err}.`);
     }

--- a/src/githubHelper.ts
+++ b/src/githubHelper.ts
@@ -1288,5 +1288,6 @@ export class GithubHelper {
     } catch (err) {
       console.error(`\n\tSomething went wrong: ${err}.`);
     }
+    await utils.sleep(this.delayInMs);
   }
 }

--- a/src/githubHelper.ts
+++ b/src/githubHelper.ts
@@ -1282,6 +1282,7 @@ export class GithubHelper {
       console.log(`Creating repo ${params.owner}/${params.repo}...`);
       await this.githubApi.repos.createForAuthenticatedUser({
         name: this.githubRepo,
+        private: true,
       });
       console.log('\t...done.');
     } catch (err) {

--- a/src/githubHelper.ts
+++ b/src/githubHelper.ts
@@ -1261,6 +1261,9 @@ export class GithubHelper {
     return `Commented on [${ref}](${repoLink}/compare/${base_sha}..${head_sha}${slug})\n\n`;
   }
 
+  /**
+   * Asks for confirmation and then maybe deletes the GH repository, then creates it again.
+   */
   async recreateRepo() {
     let params = {
       owner: this.githubOwner,

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,7 @@ import { Octokit as GitHubApi } from '@octokit/rest';
 import { throttling } from '@octokit/plugin-throttling';
 import { Gitlab } from '@gitbeaker/node';
 
+import { default as readlineSync } from 'readline-sync';
 import * as fs from 'fs';
 
 import AWS from 'aws-sdk';
@@ -101,10 +102,24 @@ if (!settings.gitlab.projectId) {
   gitlabHelper.listProjects();
 } else {
   // user has chosen a project
+  if (settings.github.recreateRepo === true) {
+    recreate();
+  }
   migrate();
 }
 
 // ----------------------------------------------------------------------------
+
+async function recreate() {
+  readlineSync.setDefaultOptions({
+    limit: ['no', 'yes'],
+    limitMessage: 'Please enter yes or no',
+    defaultInput: 'no',
+  });
+  const ans = readlineSync.question('Delete and recreate? [yes/no] ');
+  if (ans == 'yes') await githubHelper.recreateRepo();
+  else console.log("OK, I won't delete anything then.");
+}
 
 /*
  * TODO description

--- a/src/index.ts
+++ b/src/index.ts
@@ -110,6 +110,9 @@ if (!settings.gitlab.projectId) {
 
 // ----------------------------------------------------------------------------
 
+/**
+ * Asks for confirmation and maybe recreates the GitHub repository.
+ */
 async function recreate() {
   readlineSync.setDefaultOptions({
     limit: ['no', 'yes'],

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -41,6 +41,7 @@ export interface GithubSettings {
   repo: string;
   timeout?: number;
   username?: string; // when is this set???
+  recreateRepo?: boolean;
 }
 
 export interface GitlabSettings {


### PR DESCRIPTION
This is useful when debugging: set `settings.github.recreateRepo: true` and given the access token `delete_repo` rights to always delete and recreate the destination repository before migrating.