### PR TITLE
Enable note migration by resolving correct response

### DIFF
--- a/src/githubHelper.ts
+++ b/src/githubHelper.ts
@@ -885,8 +885,8 @@ export class GithubHelper {
 
       try {
         // try to create the GitHub pull request from the GitLab issue
-        await this.githubApi.pulls.create(props);
-        return Promise.resolve({ data: null }); // need to return null promise for parent to wait on
+        const response = await this.githubApi.pulls.create(props);
+        return Promise.resolve(response);
       } catch (err) {
         if (err.status === 422) {
           console.error(


### PR DESCRIPTION
Prior to this change, we would ignore the
```
await this.githubApi.pulls.create(props);
```
return value, which is the actual Pull Request data. As a result, none of the logic beyond creating the Pull Request could run: https://github.com/piceaTech/node-gitlab-2-github/blob/master/src/githubHelper.ts#L792

It looks like https://github.com/piceaTech/node-gitlab-2-github/commit/d65ac3f72f02ed5b670e847e278d4c736a7f5f1a caused this issue, but I'm not sure if my solution causes a regression.