### PR TITLE
fixed bug where recreating repo for an organisation,…

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,10 @@ Point this to the api. The default is `api.github.com`.
 
 Under which organisation or user will the new project be hosted
 
+#### github.ownerIsOrg
+
+A boolean indicator (default is *false*) to specify that the owner of this repo is an Organisation.
+
 #### github.token
 
 Go to [Settings / Developer settings / Personal access tokens](https://github.com/settings/tokens). Generate a new token with `repo` scope and copy that into the `settings.ts`
@@ -89,6 +93,8 @@ What is the name of the new repo
 #### github.recreateRepo
 
 If true (default is false), we will try to delete the destination github repository if present, and (re)create it. The github token must be granted `delete_repo` scope. The newly created repository will be made private by default.
+
+If you've set `github.recreateRepo` to true and the repo belongs to an Organisation, the `github.ownerIsOrg` flag **must** be set as true.
 
 This is useful when debugging this tool or a specific migration. You will always be prompted for confirmation.
 

--- a/sample_settings.ts
+++ b/sample_settings.ts
@@ -11,6 +11,7 @@ export default {
     // baseUrl: 'https://github.mycompany.com:123/etc',
     // apiUrl: 'https//api.github.mycompany.com',
     owner: '{{repository owner (user or organization)}}',
+    ownerIsOrg: false,
     token: '{{token}}',
     token_owner: '{{token_owner}}',
     repo: '{{repo}}',

--- a/src/githubHelper.ts
+++ b/src/githubHelper.ts
@@ -60,7 +60,9 @@ export class GithubHelper {
   githubApi: GitHubApi;
   githubUrl: string;
   githubOwner: string;
+  githubOwnerIsOrg: boolean;
   githubToken: string;
+  githubTokenOwner: string;
   githubRepo: string;
   githubTimeout?: number;
   gitlabHelper: GitlabHelper;
@@ -80,7 +82,9 @@ export class GithubHelper {
       ? githubSettings.baseUrl
       : gitHubLocation;
     this.githubOwner = githubSettings.owner;
+    this.githubOwnerIsOrg = githubSettings.ownerIsOrg ?? false;
     this.githubToken = githubSettings.token;
+    this.githubTokenOwner = githubSettings.token_owner;
     this.githubRepo = githubSettings.repo;
     this.githubTimeout = githubSettings.timeout;
     this.gitlabHelper = gitlabHelper;
@@ -1398,11 +1402,20 @@ export class GithubHelper {
       else console.error(`\n\tSomething went wrong: ${err}.`);
     }
     try {
-      console.log(`Creating repo ${params.owner}/${params.repo}...`);
-      await this.githubApi.repos.createForAuthenticatedUser({
-        name: this.githubRepo,
-        private: true,
-      });
+      if (this.githubOwnerIsOrg) {
+        console.log(`Creating repo in organisation ${this.githubOwner}/${this.githubRepo}...`);
+        await this.githubApi.repos.createInOrg({
+          org: this.githubOwner,
+          name: this.githubRepo,
+          private: true,
+        });
+      } else {
+        console.log(`Creating repo ${this.githubTokenOwner}/${this.githubRepo}...`);
+        await this.githubApi.repos.createForAuthenticatedUser({
+          name: this.githubRepo,
+          private: true,
+        });
+      }
       console.log('\t...done.');
     } catch (err) {
       console.error(`\n\tSomething went wrong: ${err}.`);

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -38,6 +38,7 @@ export interface GithubSettings {
   baseUrl?: string;
   apiUrl?: string;
   owner: string;
+  ownerIsOrg?: boolean;
   token: string;
   token_owner: string;
   repo: string;


### PR DESCRIPTION
the repo recreated in authenticated user account instead (fix issue #153).

This is due to wrong API was used to create Organisation's repo.

Have to set `github.ownerIsOrg` to true in `settings.ts` if the repo belongs to an Organisation.