### PR TITLE
Use https instead of http as default gitlab value

### DIFF
--- a/src/gitlabHelper.ts
+++ b/src/gitlabHelper.ts
@@ -37,7 +37,7 @@ export class GitlabHelper {
     this.gitlabUrl = gitlabSettings.url;
     this.gitlabToken = gitlabSettings.token;
     this.gitlabProjectId = gitlabSettings.projectId;
-    this.host = gitlabSettings.url ? gitlabSettings.url : 'http://gitlab.com';
+    this.host = gitlabSettings.url ? gitlabSettings.url : 'https://gitlab.com';
     this.host = this.host.endsWith('/')
       ? this.host.substring(0, this.host.length - 1)
       : this.host;


### PR DESCRIPTION
Use HTTPS instead of HTTP as the default GitLab value.

The problem was that atachment downloading didn't work with the default `http` value after switching to `https` the attachment downloading started working.