### PR TITLE
Feature: transfer label descriptions

### DIFF
--- a/sample_settings.ts
+++ b/sample_settings.ts
@@ -48,6 +48,7 @@ export default {
   useReplacementIssuesForCreationFails: true,
   useIssuesForAllMergeRequests: false,
   filterByLabel: null,
+  trimOversizedLabelDescriptions: false,
   skipMergeRequestStates: [],
   skipMatchingComments: [],
   mergeRequests: {

--- a/src/githubHelper.ts
+++ b/src/githubHelper.ts
@@ -49,6 +49,7 @@ export interface MilestoneImport {
 export interface SimpleLabel {
   name: string;
   color: string;
+  description: string;
 }
 
 export interface SimpleMilestone {
@@ -765,6 +766,7 @@ export class GithubHelper {
       repo: this.githubRepo,
       name: label.name,
       color: label.color.substring(1), // remove leading "#" because gitlab returns it but github wants the color without it
+      description: label.description,
     };
 
     await utils.sleep(this.delayInMs);

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,6 +16,11 @@ import * as fs from 'fs';
 
 import AWS from 'aws-sdk';
 
+const CCERROR = '\x1b[31m%s\x1b[0m'; // red
+const CCWARN = '\x1b[33m%s\x1b[0m'; // yellow
+const CCINFO = '\x1b[36m%s\x1b[0m'; // cyan
+const CCSUCCESS = '\x1b[32m%s\x1b[0m'; // green
+
 const counters = {
   nrOfPlaceholderIssues: 0,
   nrOfReplacementIssues: 0,
@@ -326,6 +331,7 @@ async function transferMilestones(usePlaceholders: boolean) {
  */
 async function transferLabels(attachmentLabel = true, useLowerCase = true) {
   inform('Transferring Labels');
+  console.warn(CCWARN,'NOTE (2022): GitHub descriptions are limited to 100 characters!');
 
   // Get a list of all labels associated with this project
   let labels: SimpleLabel[] = await gitlabApi.Labels.all(
@@ -359,6 +365,19 @@ async function transferLabels(attachmentLabel = true, useLowerCase = true) {
 
     if (!githubLabels.find(l => l === label.name)) {
       console.log('Creating: ' + label.name);
+
+      if (label.description.length > 100) {
+        const trimmedDescription = label.description.slice(0,100);
+        if (settings.trimOversizedLabelDescriptions) {
+          console.warn(CCWARN,`Description too long (${label.description.length}), it was trimmed: \n "${label.description}"\n\t to\n "${trimmedDescription}"`);
+          label.description = trimmedDescription;
+        } else {
+          console.warn(CCWARN,`Description too long (${label.description.length}), it was excluded.`);
+          console.debug(` "${label.description}"`);
+          label.description = '';
+        }
+      }
+
       try {
         // process asynchronous code in sequence
         await githubHelper.createLabel(label).catch(x => {});

--- a/src/index.ts
+++ b/src/index.ts
@@ -340,6 +340,7 @@ async function transferLabels(attachmentLabel = true, useLowerCase = true) {
     const hasAttachmentLabel = {
       name: 'has attachment',
       color: '#fbca04',
+      description: 'Attachment was not transfered from GitLab',
     };
     labels.push(hasAttachmentLabel);
   }
@@ -347,6 +348,7 @@ async function transferLabels(attachmentLabel = true, useLowerCase = true) {
   const gitlabMergeRequestLabel = {
     name: 'gitlab merge request',
     color: '#b36b00',
+    description: '',
   };
   labels.push(gitlabMergeRequestLabel);
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -333,7 +333,7 @@ async function transferLabels(attachmentLabel = true, useLowerCase = true) {
   inform('Transferring Labels');
   console.warn(CCWARN,'NOTE (2022): GitHub descriptions are limited to 100 characters, and do not accept 4-byte Unicode');
 
-  const invalidUnicode = /[\u{10000}-\u{10FFFF}]/gu;
+  const invalidUnicode = /[\u{10000}-\u{10FFFF}]|(?![*#0-9]+)[\p{Emoji}\p{Emoji_Modifier}\p{Emoji_Component}\p{Emoji_Modifier_Base}\p{Emoji_Presentation}]/gu;
 
   // Get a list of all labels associated with this project
   let labels: SimpleLabel[] = await gitlabApi.Labels.all(

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -25,6 +25,7 @@ export default interface Settings {
   useReplacementIssuesForCreationFails: boolean;
   useIssuesForAllMergeRequests: boolean;
   filterByLabel?: string;
+  trimOversizedLabelDescriptions: boolean;
   skipMergeRequestStates: string[];
   skipMatchingComments: string[];
   mergeRequests: {


### PR DESCRIPTION
- Now when labels are transferred, their descriptions are as well!  
- Added some color options for your console output, feel free to use elsewhere :)
- `trimOversizedLabelDescriptions` boolean option to trim them to the maximum allowable length instead of leaving blank, maybe a bit excessive feel free to remove this logic.

![image](https://user-images.githubusercontent.com/159109/196024109-514def7b-9983-467a-815e-115b1236b30e.png)
