### PR TITLE
Add support to filter out archived GitLab projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,10 @@ Go to [Settings / Access Tokens](https://gitlab.com/-/profile/personal_access_to
 
 Leave it null for the first run of the script. Then the script will show you which projects there are. Can be either string or number.
 
+#### gitlab.listArchivedProjects
+
+When listing projects on the first run (projectID = null), include archived ones too. The default is *true*.
+
 #### gitlab.sessionCookie
 
 GitLab's API [does not allow downloading of attachments](https://gitlab.com/gitlab-org/gitlab/-/issues/24155) and only images can be downloaded using HTTP. To work around this limitation and enable binary attachments to be migrated one can use the session cookie set in the browser after logging in to the gitlab instance. The cookie is named `_gitlab_session`.

--- a/sample_settings.ts
+++ b/sample_settings.ts
@@ -5,6 +5,7 @@ export default {
     // url: 'https://gitlab.mycompany.com',
     token: '{{gitlab private token}}',
     projectId: null,
+    listArchivedProjects: true,
     sessionCookie: null,
   },
   github: {

--- a/src/gitlabHelper.ts
+++ b/src/gitlabHelper.ts
@@ -23,6 +23,7 @@ export class GitlabHelper {
   gitlabUrl?: string;
   gitlabToken: string;
   gitlabProjectId: number;
+  archived?: boolean;
   sessionCookie: string;
 
   host: string;
@@ -41,6 +42,7 @@ export class GitlabHelper {
     this.host = this.host.endsWith('/')
       ? this.host.substring(0, this.host.length - 1)
       : this.host;
+    this.archived = gitlabSettings.listArchivedProjects ?? true;
     this.sessionCookie = gitlabSettings.sessionCookie;
     this.allBranches = null;
   }
@@ -50,7 +52,12 @@ export class GitlabHelper {
    */
   async listProjects() {
     try {
-      const projects = await this.gitlabApi.Projects.all({ membership: true });
+      let projects;
+      if (this.archived) {
+        projects = await this.gitlabApi.Projects.all({ membership: true });
+      } else {
+        projects = await this.gitlabApi.Projects.all({ membership: true, archived: this.archived });
+      }
 
       // print each project with info
       for (let project of projects) {

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -51,6 +51,7 @@ export interface GitlabSettings {
   url?: string;
   token: string;
   projectId: number;
+  listArchivedProjects?: boolean;
   sessionCookie: string;
 }
 


### PR DESCRIPTION
This adds support to filter out archived GitLab projects on the first run, when listing projects.

For compatibility reasons I have kept this option true by default, i.e. archived projects will be included in the list.