### PR TITLE
remove extranious selector that prevents matching issues

### DIFF
--- a/src/githubHelper.ts
+++ b/src/githubHelper.ts
@@ -159,7 +159,7 @@ export class GithubHelper {
         owner: this.githubOwner,
         repo: this.githubRepo,
         state: 'all',
-        labels: 'gitlab merge request',
+        // labels: 'gitlab merge request',
         per_page: perPage,
         page: page,
       });


### PR DESCRIPTION
Restarting a migration will fail to recognize existing github issues since the selector is looking for labels. Removing that enables the correct behaviour.