### PR TITLE
Add option to save a list of users

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,6 +190,12 @@ and add them to github in chronological order, but it would not preserve the ori
 
 As default it is set to false. Doesn't fire the requests to github api and only does the work on the gitlab side to test for wonky cases before using up api-calls
 
+### exportUsers
+
+If this is set to true (default is false) then a file called "users.txt" wil be created containing all
+usernames that contributed to the repository. You can use this with dryRun when you need to map users
+for the migration, but you do not know all the source usernames.
+
 ### useIssueImportAPI
 
 Set to true (default) to enable using the [GitHub preview API for importing issues](https://gist.github.com/jonmagic/5282384165e0f86ef105). This allows setting the date for issues and comments instead of inserting an additional line in the body.

--- a/sample_settings.ts
+++ b/sample_settings.ts
@@ -44,6 +44,7 @@ export default {
     releases: true,
   },
   dryRun: false,
+  exportUsers: false,
   useIssueImportAPI: true,
   usePlaceholderMilestonesForMissingMilestones: true,
   usePlaceholderIssuesForMissingIssues: true,

--- a/src/index.ts
+++ b/src/index.ts
@@ -224,6 +224,11 @@ async function migrate() {
         await transferMergeRequests();
       }
     }
+
+    if (settings.exportUsers) {
+      const users = Array.from(githubHelper.users.values()).join("\n");
+      fs.writeFileSync('users.txt', users);
+    }
   } catch (err) {
     console.error('Error during transfer:');
     console.error(err);

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -1,5 +1,6 @@
 export default interface Settings {
   dryRun: boolean;
+  exportUsers: boolean;
   gitlab: GitlabSettings;
   github: GithubSettings;
   usermap: {


### PR DESCRIPTION
Hi, I think the project is not being actively maintained, but leaving this PR here in case someone else needs a list of the users from the comments/notes/labels/etc. in order to create the user map.

I didn't worry about adding a test, or verifying if I were adding users in an optimal way due to time. It simply uses a `Set` and adds everything it finds when the code touches `usermap`, and later dumps this list in a `users.txt` file. You can then use this list from GitLab users to locate their GitHub user Ids, and create a usermap (i.e. first use `dryRun`).

cc @LuiggiTenorioK