### PR TITLE
Fix GitLab username saved after conversion

### DIFF
--- a/src/githubHelper.ts
+++ b/src/githubHelper.ts
@@ -1163,6 +1163,14 @@ export class GithubHelper {
     if (add_line) str = GithubHelper.addMigrationLine(str, item, repoLink);
     let reString = '';
 
+    // Store usernames found in the text
+    const matches: Array<string> = str.match(usernameRegex);
+    if (matches && matches.length > 0) {
+      for (const username of matches) {
+        this.users.add(username.substring(1));
+      }
+    }
+
     //
     // User name conversion
     //
@@ -1173,14 +1181,6 @@ export class GithubHelper {
         new RegExp(reString, 'g'),
         match => '@' + settings.usermap[match.substring(1)]
       );
-    }
-
-    // Store usernames found in the text
-    const matches: Array<string> = str.match(usernameRegex);
-    if (matches && matches.length > 0) {
-      for (const username of matches) {
-        this.users.add(username.substring(1));
-      }
     }
 
     //


### PR DESCRIPTION
Hi! I saw that there was an error on the last PR https://github.com/piceaTech/node-gitlab-2-github/pull/205 we submitted with @kinow about the list of users.

The problem is that in the final GitLab user list, the already converted usernames from GitHub were added to the list instead of the GitLab ones when converting the issues/comments.

This quick fix only moves that code snippet to the right place (before converting the username).