### PR TITLE
Detect when MR has a description that is too long

### DIFF
--- a/src/githubHelper.ts
+++ b/src/githubHelper.ts
@@ -566,6 +566,10 @@ export class GithubHelper {
     issue: IssueImport,
     comments: CommentImport[]
   ): Promise<number | null> {
+    // see: https://github.com/orgs/community/discussions/27190
+    if (issue.body.length > 65536) {
+      throw `${issue.title} has a body longer than 65536 characters. Please shorten it.`;
+    }
     // create the GitHub issue from the GitLab issue
     let pending = await this.githubApi.request(
       `POST /repos/${settings.github.owner}/${settings.github.repo}/import/issues`,

--- a/src/index.ts
+++ b/src/index.ts
@@ -589,6 +589,8 @@ async function transferMergeRequests() {
           'Could not create pull request: !' + mr.iid + ' - ' + mr.title
         );
         console.error(err);
+        // Stop execution to be able to correct issue
+        process.exit(1);
       }
     } else {
       if (githubRequest) {


### PR DESCRIPTION
Throw an error when the max length of the body is exceeded.

In order for the execution to stop and not continue with the remaining merge requests it is necessary to `break` here: https://github.com/piceaTech/node-gitlab-2-github/blob/6b1d903b728399f857d7f536c78ee6e32d858215/src/index.ts#L587-L592

If this is desired, I can add it.

Fixes #208 