### PR TITLE
Add merged label to PR if the MR was merged

### DIFF
--- a/src/githubHelper.ts
+++ b/src/githubHelper.ts
@@ -428,6 +428,12 @@ export class GithubHelper {
       labels.push('has attachment');
     }
 
+    labels.push('gitlab merge request');
+
+    if (item.state === 'merged') {
+      labels.push('merged');
+    }
+
     return labels;
   }
 


### PR DESCRIPTION
Add the label `merged` to the PR if merge request was merged on GitLab.

Also added the `gitlab merge request` label to be consistent with what is done with issues.
This helps to know that this was previously a merge request on GitLab.

Fixes #209 