### PR TITLE
Replace GitHub URLs outside of the owner namespace to avoid backlink spam

### DIFF
--- a/src/githubHelper.ts
+++ b/src/githubHelper.ts
@@ -1275,6 +1275,15 @@ export class GithubHelper {
       milestoneReplacer(p1, '')
     );
 
+    // Replace github.com URLs to other organizations with redirect.github.com to avoid backlink spam
+    let urlMassager = (str: string) => {
+      return 'redirect.github.com';
+    }
+
+    // Keep owner internal links/back links intact
+    reString = `((?:to|redirect\\.|www\\.)?github\\.com)(?!\\/${settings.github.owner}\\/)`;
+    str = str.replace(new RegExp(reString, 'g'), (_, p1) => urlMassager(p1));
+
     //
     // Label reference conversion
     //


### PR DESCRIPTION
Replaces `github.com` in URLs with `redirect.github.com` to avoid backlink spam.
This is only done when the URL points to outside of the owner of the GitHub namespace, e.g., the organization, to keep internal backlinks.

Fixes #211