### PR TITLE
Change GitLab attachment URL to current one

### DIFF
--- a/src/gitlabHelper.ts
+++ b/src/gitlabHelper.ts
@@ -116,7 +116,7 @@ export class GitlabHelper {
    */
   async getAttachment(relurl: string) {
     try {
-      const attachmentUrl = this.host + '/' + this.projectPath + relurl;
+      const attachmentUrl = this.host + '/-/project/' + this.gitlabProjectId + relurl;
       const data = (
         await axios.get(attachmentUrl, {
           responseType: 'arraybuffer',
@@ -129,7 +129,7 @@ export class GitlabHelper {
       ).data;
       return Buffer.from(data, 'binary');
     } catch (err) {
-      console.error(`Could not download attachment #${relurl}.`);
+      console.error(`Could not download attachment #${relurl}: ${err.response.statusText}`);
       return null;
     }
   }


### PR DESCRIPTION
GitLab seems to have changed the URL for attachments.

Previously, it was `gitlab.com/<group>/<project>/uploads/<file>`, whereas now it is `gitlab.com/-/project/<projectId>/uploads/<file>`.

While old attachment URLs still work, it seems that new attachments can only be retrieved under the new URL.
In the UI, the link also goes to the new URL (for all of them).