### PR TITLE
Include timezone in date format of migration line

### DIFF
--- a/src/githubHelper.ts
+++ b/src/githubHelper.ts
@@ -1331,6 +1331,7 @@ export class GithubHelper {
       hour: 'numeric',
       minute: 'numeric',
       hour12: false,
+      timeZoneName: 'short',
     };
 
     const formattedDate = new Date(item.created_at).toLocaleString(


### PR DESCRIPTION
Datetimes on GitLab and GitHub generally include the timezone when hovering over the datetime.

Include the timezone in the migration line so that it is clear what timezone the mentioned datetime corresponds to since the shown datetime depends on the timezone the tool is executed in.