### PR TITLE
Detect existing issues by title and GitLab URL to avoid skipping an item

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -464,7 +464,7 @@ async function transferIssues() {
   for (let issue of issues) {
     // try to find a GitHub issue that already exists for this GitLab issue
     let githubIssue = githubIssues.find(
-      i => i.title.trim() === issue.title.trim()
+      i => i.title.trim() === issue.title.trim() && i.body.includes(issue.web_url)
     );
     if (!githubIssue) {
       console.log(`\nMigrating issue #${issue.iid} ('${issue.title}')...`);
@@ -563,14 +563,14 @@ async function transferMergeRequests() {
     // Try to find a GitHub pull request that already exists for this GitLab
     // merge request
     let githubRequest = githubPullRequests.find(
-      i => i.title.trim() === mr.title.trim()
+      i => i.title.trim() === mr.title.trim() && i.body.includes(mr.web_url)
     );
     let githubIssue = githubIssues.find(
       // allow for issues titled "Original Issue Name - [merged|closed]"
       i => {
         // regex needs escaping in case merge request title contains special characters
         const regex = new RegExp(escapeRegExp(mr.title.trim()) + ' - \\[(merged|closed)\\]');
-        return regex.test(i.title.trim());
+        return regex.test(i.title.trim()) && i.body.includes(mr.web_url);
       }
     );
     if (!githubRequest && !githubIssue) {


### PR DESCRIPTION
Merge requests with a "duplicate title" were not migrated.

With the addition of the GitLab URL of the migrated item in #219 it is now possible to use that to detect if an item was already migrated.