### PR TITLE
Add hint about expired session cookie if attachment retrieval fails

### DIFF
--- a/src/gitlabHelper.ts
+++ b/src/gitlabHelper.ts
@@ -129,7 +129,8 @@ export class GitlabHelper {
       ).data;
       return Buffer.from(data, 'binary');
     } catch (err) {
-      console.error(`Could not download attachment #${relurl}: ${err.response.statusText}`);
+      console.error(`Could not download attachment ${relurl}: ${err.response.statusText}`);
+      console.error('Is your session cookie still valid?');
       return null;
     }
   }


### PR DESCRIPTION
It happened to me a few times and I found it helpful to hint at it.