### PR TITLE
fix: add missing commitMap property to Settings interface

### DIFF
--- a/sample_settings.ts
+++ b/sample_settings.ts
@@ -32,6 +32,10 @@ export default {
     'gitlabgroup/projectname.1': 'GitHubOrg/projectname.1',
     'gitlabgroup/projectname.2': 'GitHubOrg/projectname.2',
   },
+  commitMap: {
+    'gitlab-commit-hash-1': 'github-commit-hash-1',
+    'gitlab-commit-hash-2': 'github-commit-hash-2',
+  },
   conversion: {
     useLowerCaseLabels: true,
     addIssueInformation: true,

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -35,6 +35,9 @@ export default interface Settings {
     log: boolean;
   };
   s3?: S3Settings;
+  commitMap: {
+    [key: string]: string;
+  };
 }
 
 export interface GithubSettings {


### PR DESCRIPTION
- Add commitMap property to Settings interface in src/settings.ts
- Add commitMap example configuration to sample_settings.ts
- Resolves TypeScript error where commitMap was used in code but missing from type definition
- Fixes type mismatch introduced in ef23755fa4ab3105221e15d5db30ea27b9f523b6 where commitMap was added to code but not to Settings interface

Fixes #241