### PR TITLE
Handle undefined milestone description gracefully

### DIFF
--- a/src/githubHelper.ts
+++ b/src/githubHelper.ts
@@ -862,7 +862,7 @@ export class GithubHelper {
   async createMilestone(milestone: MilestoneImport): Promise<SimpleMilestone> {
     // convert from GitLab to GitHub
     let bodyConverted = await this.convertIssuesAndComments(
-      milestone.description,
+      milestone.description || '',
       milestone,
       false
     );


### PR DESCRIPTION
This change fixes type error on importing milestone with no description.  

```
TypeError: Cannot read properties of null (reading 'match')
```