### PR TITLE
Implement CSV-based batch migration with per-project repository mapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,8 @@ Go to [Settings / Access Tokens](https://gitlab.com/-/profile/personal_access_to
 
 #### gitlab.projectID
 
-Leave it null for the first run of the script. Then the script will show you which projects there are. Can be either string or number.
+Leave it null for the first run of the script (leave csvImport.projectMapCsv empty either). Then the script will show you which projects there are. Can be either string or number.
+Leave it null if you want to import multiple projects via csv file (set `csvImport` instead).
 
 #### gitlab.listArchivedProjects
 
@@ -155,6 +156,23 @@ Maps the usernames from gitlab to github. If the assinee of the gitlab issue is 
 ### projectmap
 
 When one renames the project while transfering so that the projects don't loose there links to the mentioned issues.
+
+### csvImport.projectMapCsv
+
+Optional name of CSV file (located in project root) containing multiple projects for migration. If set, it overrules `gitlab.projectId` and `github.repo`.
+CSV file must contain the following values: GitLab project ID, GitLab project path, GitHub project path, e.g. 213,gitlab_namespace/gitlab_projectname,github_namespace/github_projectname
+
+### csvImport.gitlabProjectIdColumn
+
+Column in CSV file containing GitLab project ID
+
+### csvImport.gitlabProjectPathColumn
+
+Column in CSV file containing GitLab path
+
+### csvImport.githubProjectPathColumn
+
+Column in CSV file containing GitHub path
 
 ### conversion
 

--- a/src/githubHelper.ts
+++ b/src/githubHelper.ts
@@ -103,16 +103,17 @@ export class GithubHelper {
 
     this.members = new Set<string>();
 
-    // TODO: won't work if ownerIsOrg is false
-    githubApi.orgs.listMembers(  {
-      org: this.githubOwner,
-    }).then(members => {
-      for (let member of members.data) {
-        this.members.add(member.login);
-      }
-    }).catch(err => {
-      console.error(`Failed to fetch organization members: ${err}`);
-    });
+    if (this.githubOwnerIsOrg) {
+      githubApi.orgs.listMembers(  {
+        org: this.githubOwner,
+      }).then(members => {
+        for (let member of members.data) {
+          this.members.add(member.login);
+        }
+      }).catch(err => {
+        console.error(`Failed to fetch organization members: ${err}`);
+      });
+    }
   }
 
   /*

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -9,6 +9,12 @@ export default interface Settings {
   projectmap: {
     [key: string]: string;
   };
+  csvImport?:{
+    projectMapCsv?: string;
+    gitlabProjectIdColumn?: number;
+    gitlabProjectPathColumn?: number;
+    githubProjectPathColumn?: number;
+    }
   conversion: {
     useLowerCaseLabels: boolean;
     addIssueInformation: boolean;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -3,11 +3,86 @@ import settings from '../settings';
 import * as mime from 'mime-types';
 import * as path from 'path';
 import * as crypto from 'crypto';
+import * as fs from 'fs';
 import S3 from 'aws-sdk/clients/s3';
 import { GitlabHelper } from './gitlabHelper';
 
 export const sleep = (milliseconds: number) => {
   return new Promise(resolve => setTimeout(resolve, milliseconds));
+};
+
+export const readProjectsFromCsv = (
+  filePath: string,
+  idColumn: number = 0,
+  gitlabPathColumn: number = 1,
+  githubPathColumn: number = 2
+): Map<number, [string, string]> => {
+  try {
+    if (!fs.existsSync(filePath)) {
+      throw new Error(`CSV file not found: ${filePath}`);
+    }
+
+    const content = fs.readFileSync(filePath, 'utf-8');
+    const lines = content.split(/\r?\n/);
+    const projectMap = new Map<number, [string, string]>();
+    let headerSkipped = false;
+
+    for (let i = 0; i < lines.length; i++) {
+      const line = lines[i].trim();
+      
+      if (!line || line.startsWith('#')) {
+        continue;
+      }
+
+      const values = line.split(',').map(v => v.trim());
+      const maxColumn = Math.max(idColumn, gitlabPathColumn, githubPathColumn);
+      
+      if (maxColumn >= values.length) {
+        console.warn(`Warning: Line ${i + 1} has only ${values.length} column(s), skipping (need column ${maxColumn})`);
+        if (!headerSkipped) {
+          headerSkipped = true;
+        }
+        continue;
+      }
+
+      const idStr = values[idColumn];
+      const gitlabPath = values[gitlabPathColumn];
+      const githubPath = values[githubPathColumn];
+
+      if (!headerSkipped) {
+        const num = parseInt(idStr, 10);
+        if (isNaN(num) || idStr.toLowerCase().includes('id') || idStr.toLowerCase().includes('project')) {
+          console.log(`Skipping CSV header row: "${line}"`);
+          headerSkipped = true;
+          continue;
+        }
+        headerSkipped = true;
+      }
+
+      if (!idStr || !gitlabPath || !githubPath) {
+        console.warn(`Warning: Line ${i + 1} has empty values, skipping`);
+        continue;
+      }
+
+      const projectId = parseInt(idStr, 10);
+      if (isNaN(projectId)) {
+        console.warn(`Warning: Line ${i + 1}: Invalid project ID "${idStr}", skipping`);
+        continue;
+      }
+
+      projectMap.set(projectId, [gitlabPath, githubPath]);
+    }
+
+    if (projectMap.size === 0) {
+          throw new Error(`No valid project mappings found in CSV file: ${filePath}`);
+        }
+    
+        console.log(`✓ Loaded ${projectMap.size} project mappings from CSV`);
+        return projectMap;
+      } catch (err) {
+        console.error(`Error reading project mapping CSV file: ${err.message}`);
+        throw err;
+  }
 };
 
 // Creates new attachments and replaces old links


### PR DESCRIPTION
This PR adds CSV-based batch migration support:

1. **CSV file support for project IDs** - Load multiple project IDs from a CSV file located in project root (at least with columns for GitLab project ID, GitLab path name and GitHub path name)
2. **CSV-based GitHub repository mapping** - Each GitLab project can target a different GitHub repository
3. **Organization/User flexibility** - Projects can be mapped from organizations to individual user accounts or vice versa
4. **Project name logging** - Display project names/paths in logs for better visibility
5. **Automatic processing loop** - Process all projects sequentially in one run
