### PR TITLE
Fix compare link when creating line ref

### DIFF
--- a/src/githubHelper.ts
+++ b/src/githubHelper.ts
@@ -1735,7 +1735,7 @@ export class GithubHelper {
       ref = head_sha;
     }
 
-    let lineRef = `Commented on [${ref}](${repoLink}/compare/${base_sha}..${head_sha}${slug})\n\n`;
+    let lineRef = `Commented on [${ref}](${repoLink}/compare/${base_sha}...${head_sha}${slug})\n\n`;
 
     if (position.line_range) {
       if (position.line_range.start.type === 'new') {


### PR DESCRIPTION
There was a missing `.` in the `/compare` link (e.g. https://github.com/piceaTech/node-gitlab-2-github/compare/v0.1.4...v0.1.5)