### PR TITLE
fix: Make milestone id assignment bulletproof

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -321,8 +321,9 @@ async function transferMilestones(usePlaceholders: boolean) {
   let milestones: (GitLabMilestone | MilestoneImport)[] =
     await gitlabApi.ProjectMilestones.all(settings.gitlab.projectId);
 
-  // sort milestones in ascending order of when they were created (by id)
-  milestones = milestones.sort((a, b) => a.id - b.id);
+  // sort milestones in ascending order of their project-scoped id (iid),
+  // since the placeholder logic relies on iid ordering
+  milestones = milestones.sort((a, b) => a.iid - b.iid);
 
   // get a list of the current milestones in the new GitHub repo (likely to be empty)
   const githubMilestones = await githubHelper.getAllGithubMilestones();


### PR DESCRIPTION
There is a bug in the script, which can causes an infinite loop, trying to increase issue numbers. This is caused by milestones sorted by `id` not by `iid`. I had a repo, where both were not the same and `iid` was the real milestone id. It can happen if you work with old repos, which e. g. have already been migrated once. This PR fixes it.