### PR TITLE
feat: remove GitLab image dimension text

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -92,7 +92,8 @@ export const migrateAttachments = async (
   s3: S3Settings | undefined,
   gitlabHelper: GitlabHelper
 ) => {
-  const regexp = /(!?)\[([^\]]+)\]\((\/uploads[^)]+)\)/g;
+  // Also matches optional GitLab-specific {width=... height=...} attributes after the link
+  const regexp = /(!?)\[([^\]]+)\]\((\/uploads[^)]+)\)(\{[^}]*\})?/g;
 
   // Maps link offset to a new name in S3
   const offsetToAttachment: {


### PR DESCRIPTION
At some time GitLab introduced the feature to specify inline image attributes such as `![…](…){width=... height=...}`. With the current version of this project, they are migrated as text, which is ugly and has no use. This PR adjusts the regex targeting attachments to also target attributes in `{…}`, so that they won’t appear as text after migration.