### PR TITLE
feat: allow collaborators as members

### DIFF
--- a/src/githubHelper.ts
+++ b/src/githubHelper.ts
@@ -113,6 +113,17 @@ export class GithubHelper {
       }).catch(err => {
         console.error(`Failed to fetch organization members: ${err}`);
       });
+    } else {
+      githubApi.repos.listCollaborators({
+        owner: this.githubOwner,
+        repo: this.githubRepo,
+      }).then(collaborators => {
+        for (let collaborator of collaborators.data) {
+          this.members.add(collaborator.login);
+        }
+      }).catch(err => {
+        console.error(`Failed to fetch repository collaborators: ${err}`);
+      });
     }
   }
 


### PR DESCRIPTION
If you’re working on a non-organization repo, you sometimes might also want to connect collaborators. This PR makes that possible in the same way as in organization repos.